### PR TITLE
feat: Safe Breeding View

### DIFF
--- a/mewgenics_manager.py
+++ b/mewgenics_manager.py
@@ -42,6 +42,22 @@ def _valid_str(s) -> bool:
     """Reject None, empty, and game filler strings like 'none' or 'defaultmove'."""
     return bool(s) and s.strip().lower() not in _JUNK_STRINGS
 
+def _normalize_gender(raw_gender: Optional[str]) -> str:
+    """
+    Normalize save-data gender variants to app-level values:
+      - maleX   -> "male"
+      - femaleX -> "female"
+      - spidercat (ditto-like) -> "?"
+    """
+    g = (raw_gender or "").strip().lower()
+    if g.startswith("male"):
+        return "male"
+    if g.startswith("female"):
+        return "female"
+    if g == "spidercat":
+        return "?"
+    return "?"
+
 def _with_min_font_px(stylesheet: str, min_px: int = _ACCESSIBILITY_MIN_FONT_PX) -> str:
     """Clamp stylesheet font-size declarations to an accessible minimum."""
     if not stylesheet or "font-size" not in stylesheet:
@@ -564,7 +580,14 @@ class Cat:
         self.visual_mutation_ids = [T[i] for i in range(14, 29) if i < 72 and T[i] != 0]
 
         r.skip(12)
-        self.gender = r.str() or "?"
+        raw_gender = r.str()
+        # Authoritative sex enum near the name block:
+        #   0 = male, 1 = female, 2 = undefined/both (ditto-like)
+        sex_code = raw[_name_end + 8] if (_name_end + 9) <= len(raw) else None
+        self.gender = {0: "male", 1: "female", 2: "?"}.get(
+            sex_code,
+            _normalize_gender(raw_gender),
+        )
         r.f64()
 
         self.stat_base = [r.u32() for _ in range(7)]
@@ -688,17 +711,7 @@ class Cat:
         if vis:
             self.mutations = vis + self.mutations
 
-        # For cats whose deep-blob gender string resolved cleanly to "male"/"female",
-        # trust that result — it is authoritative and overriding it has been shown
-        # to mis-gender some cats (e.g. Midna).  Only attempt the sex_u16 fallback
-        # at _name_end+8 when the deep-blob read returned something ambiguous (e.g.
-        # ditto cats, where the parser position drifts and returns the wrong string).
-        if self.gender not in ("male", "female"):
-            try:
-                sex_u16 = struct.unpack_from('<H', raw, _name_end + 8)[0]
-                self.gender = {1: "male", 2: "female"}.get(sex_u16, "female")
-            except Exception:
-                pass
+        # Legacy token fallback is already handled above when sex_code is unavailable.
 
     # ── Display helpers ────────────────────────────────────────────────────
 
@@ -713,7 +726,7 @@ class Cat:
         g = (self.gender or "").strip().lower()
         if g.startswith("male"):   return "M"
         if g.startswith("female"): return "F"
-        return "F"  # unknown/ditto defaults to F
+        return "?"
 
     @property
     def can_move(self) -> bool:
@@ -863,14 +876,19 @@ def can_breed(a: Cat, b: Cat) -> tuple[bool, str]:
     """Return (ok, reason). reason is non-empty only when ok is False."""
     if a is b:
         return False, "Cannot pair a cat with itself"
-    ga, gb = a.gender_display, b.gender_display
-    if ga == "M" and gb == "F":
+    ga = (a.gender or "?").strip().lower()
+    gb = (b.gender or "?").strip().lower()
+    # Spidercat/unknown cats ('?') are allowed to pair with any gender.
+    if ga == "?" or gb == "?":
         return True, ""
-    if ga == "F" and gb == "M":
+    if ga != gb and {ga, gb} == {"male", "female"}:
         return True, ""
-    # Same sex
-    label = "female" if ga == "F" else "male"
-    return False, f"Both cats are {label} — cannot produce offspring"
+    # Same known sex
+    if ga == "female" and gb == "female":
+        return False, "Both cats are female — cannot produce offspring"
+    if ga == "male" and gb == "male":
+        return False, "Both cats are male — cannot produce offspring"
+    return False, "Cats have incompatible genders — cannot produce offspring"
 
 
 # ── Compatibility check ───────────────────────────────────────────────────────


### PR DESCRIPTION
# Branch Notes

This PR adds a clearer way to evaluate breeding pairs by introducing a relation/risk percentage, a dedicated **Safe Breeding** screen, and UI zoom/accessibility improvements.

## What changed

- Fixed gender assignemnt
- Added a new **Risk%** column in the main cats table.
- Added a **Safe Breeding** sidebar view that ranks valid partners for a selected alive cat.
- Added deeper lineage math helpers to estimate inbreeding risk from shared ancestry paths.
- Added risk labels in Safe Breeding results:
  - `0-19%`: Not Inbred
  - `20-49%`: Slightly Inbred
  - `50-99%`: Moderately Inbred
  - `100%+` (clamped to 100): Highly Inbred
- Added UI zoom controls in **Settings**:
  - Zoom In (`Ctrl+=` / `Ctrl++`)
  - Zoom Out (`Ctrl+-`)
  - Reset Zoom (`Ctrl+0`)
- Improved accessibility by enforcing minimum font sizes when scaling UI.
- Small visual/layout tuning (including font-size consistency updates).

## Math logic

The branch calculates inbreeding risk using ancestry paths and converts that to a percentage for the UI.

### 1) Build ancestor data

- `_ancestor_depths(cat)` finds how many generations away each ancestor is.
- `_ancestor_paths(cat)` builds all unique upward paths from a cat to each ancestor.
- Paths are prevented from looping through the same cat twice.

### 2) Compute raw CoI (Coefficient of Inbreeding)

For each common ancestor between Cat A and Cat B:

- take every valid path from A -> ancestor
- combine it with every valid path from B -> ancestor
- reject combinations that reuse the same cat on both sides (except the common ancestor)
- add this weight to the total:

`0.5 ** (sa + sb + 1)`

Where:

- `sa` = number of edges from A to ancestor
- `sb` = number of edges from B to ancestor

So closer shared ancestors contribute more; farther ones contribute less.

### 3) Convert raw CoI to UI Risk%

Risk percent is normalized as:

`Risk% = clamp((raw_coi / 0.25) * 100, 0, 100)`

Meaning:

- raw CoI `0.25` maps to `100%` risk
- values above that are capped at 100
- no relation stays near 0%

### 4) Shared ancestor metrics used in ranking

`shared_ancestor_counts(a, b)` returns:

- `total_shared`: all common ancestors found (within depth limit)
- `recent_shared`: common ancestors where both cats are within 3 generations

In Safe Breeding sorting:

- primary sort = lower `Risk%` first (safest on top)
- secondary tie-break uses a packed value (`recent_shared * 1000 + total_shared`) to penalize recent shared ancestry more heavily
- final tie-break = partner name

## Safe Breeding view behavior

- Shows only **alive** cats.
- Filters out invalid pairs (same sex, self-pairing, etc.) using existing breeding rules.
- For each candidate, displays:
  - Cat
  - Risk%
  - Shared Anc.
  - "Children will be" risk label
- Clicking a result row switches focus to that cat.

