### PR TITLE
Show ability & mutation descriptions with readable names from game data

### DIFF
--- a/mewgenics_manager.py
+++ b/mewgenics_manager.py
@@ -738,33 +738,64 @@ _VISUAL_MUT_DATA: dict = _load_visual_mut_data()
 # ── Visual mutation scanner ───────────────────────────────────────────────────
 
 # Mapping from T-array index → (display_part_name, gon_category).
-# T is the 72-element uint32 array read immediately after the 64-byte skip in
-# Cat.__init__.  Known mappings confirmed from game save analysis:
-#   T[0]  = texture/coat pattern
-#   T[3]  = body shape
-#   T[8]  = head shape
-# Slot IDs ≥ 300 in any of these positions indicate an active visual mutation.
-# Additional T indices (tail, ear, eye, leg, mouth) can be added here as
-# they are discovered from cats with those mutation types.
-_T_VISUAL_SLOTS: dict[int, tuple[str, str]] = {
-    0: ("Texture", "texture"),
-    3: ("Body",    "body"),
-    8: ("Head",    "head"),
-}
+# T is the 72-element uint32 array (288 bytes) read immediately after the
+# 64-byte skip in Cat.__init__.  Slot IDs ≥ 300 = active visual mutation.
+#
+# Confirmed from save-file analysis (catgen.gon + cross-referencing cats
+# with known mutations against game UI):
+#   T[0]  = texture/coat    (GON: texture)
+#   T[3]  = body shape      (GON: body)
+#   T[8]  = head shape      (GON: head)    — Fuzz T[8]=309 → "Half Moon"
+#   T[13] = tail            (GON: tail)    — G'raha T[13]=417 → Tail Mutation
+#   T[18] = eyes            (GON: eyes)    — Roberto T[18]=701 → Anophthalmia
+#   T[23] = eyes (paired copy, usually identical to T[18]; skip duplicates)
+#   T[28] = legs            (GON: legs)    — Hispancat T[28]=303 → Lobster Claws
+#   T[33] = legs (paired copy)
+#   T[38] = mouth           (GON: mouth)   — Berlioz T[38]=704 → Overbite
+#   T[43] = mouth (paired copy)
+#   T[48] = eyebrows        (GON: eyebrows)— G'raha T[48]=423 → Eyebrow Mutation
+#   T[53] = eyebrows (paired copy)
+#   T[58] = ears            (GON: ears)    — G'raha T[58]=316 → Bat Ears
+#   T[63] = ears (paired copy)
+#   T[68] = unknown (omitted; slot 415 appears there for many cats but no
+#           known GON file for this position)
+_T_VISUAL_SLOTS: list[tuple[int, str, str]] = [
+    ( 0, "Texture",  "texture"),
+    ( 3, "Body",     "body"),
+    ( 8, "Head",     "head"),
+    (13, "Tail",     "tail"),
+    (18, "Eye",      "eyes"),
+    (28, "Leg",      "legs"),
+    (38, "Mouth",    "mouth"),
+    (48, "Eyebrow",  "eyebrows"),
+    (58, "Ear",      "ears"),
+]
 
 
 def _read_visual_mutations(T: list) -> list:
-    """Return list of active visual-mutation display names from T array."""
+    """Return list of active visual-mutation display names from T array.
+
+    Paired slots (T[23]=T[18], T[33]=T[28], etc.) are deduplicated via the
+    `seen` set so each mutation appears once.
+    """
+    seen: set[int] = set()
     result = []
-    for t_idx, (part_name, gon_cat) in _T_VISUAL_SLOTS.items():
+    for t_idx, part_name, gon_cat in _T_VISUAL_SLOTS:
         if t_idx >= len(T):
             continue
         slot_id = T[t_idx]
-        if slot_id < 300:
+        if slot_id < 300 or slot_id == 0xFFFF_FFFF or slot_id in seen:
             continue
+        seen.add(slot_id)
         mut_info = _VISUAL_MUT_DATA.get(gon_cat, {}).get(slot_id)
         if mut_info:
-            display, stat_desc = mut_info
+            raw_name, stat_desc = mut_info
+            # If the GON only has a generic "Mutation NNN" name, label by body part
+            # to match the game's display (e.g. "Tail Mutation" instead of "Mutation 417")
+            if re.match(r'^Mutation \d+$', raw_name):
+                display = f"{part_name} Mutation"
+            else:
+                display = raw_name
             tip = f"{display}  —  {stat_desc}" if stat_desc else display
         else:
             display = f"{part_name} Mutation"


### PR DESCRIPTION
## Summary

  - Ability descriptions: Loads ability and passive descriptions dynamically from the game's resources.gpak at startup (abilities and passives GON files + data/text/combined.csv). Hovering over any ability chip shows its description.

<img width="812" height="207" alt="image" src="https://github.com/user-attachments/assets/5fab2794-0e93-418d-8f70-186b937e50cd" />

  - Mutation descriptions: Loads visual mutation data from data/mutations/*.gon inside the gpak. Named mutations (e.g. "Bat Ears", "Half Moon", "Lobster Claws") show their real names and effects. Generic stat mutations (e.g. slot 417 = "+2 DEX, -1 LCK") fall back to a body-part label ("Tail Mutation") matching the game's UI.

<img width="255" height="113" alt="image" src="https://github.com/user-attachments/assets/7580512f-ca6a-4602-a5be-a4f18b36b441" />

  - Readable display names: CamelCase mutation identifiers (e.g. TwoEdArm, ThunderThighs) are converted to readable names via regex splitting and a small override dict for edge cases (apostrophes, hyphens).

<img width="193" height="164" alt="image" src="https://github.com/user-attachments/assets/3f83e7c1-d559-4f7d-83c1-82f990adad63" />

  - Correct visual mutation detection: Reads mutations directly from the T-array in cat save data (slot IDs ≥ 300), using the confirmed body-part index mapping:
  T[0]=texture, T[3]=body, T[8]=head, T[13]=tail, T[18/23]=eyes, T[28/33]=legs, T[38/43]=mouth, T[48/53]=eyebrows, T[58/63]=ears
  - Passive abilities separated from visual mutations: cat.passive_abilities holds passive traits from the ability run; cat.mutations holds only visual body-part mutations. The UI shows them in distinct sections.

<img width="499" height="116" alt="image" src="https://github.com/user-attachments/assets/c180c779-ef23-4bca-93c0-6ca0644be011" />

## Test plan

  - Hover over ability chips — descriptions should appear for known abilities
  - Cats with named mutations (e.g. Half Moon, Bat Ears, Lobster Claws) show the correct name
  - Cats with generic stat mutations show a body-part label (e.g. "Tail Mutation", "Eyebrow Mutation")
  - Passive abilities (e.g. Schadenfreude) appear under abilities, not mutations
  - No regressions on cats with no mutations or no abilities
  
