### PR TITLE
Improve secondary-view responsiveness by skipping redundant set_cats

### DIFF
--- a/src/mewgenics/main_window.py
+++ b/src/mewgenics/main_window.py
@@ -255,6 +255,7 @@ class MainWindow(QMainWindow):
         self._calibration_view: Optional[CalibrationView] = None
         self._mutation_planner_view: Optional['MutationDisorderPlannerView'] = None
         self._furniture_view: Optional[FurnitureView] = None
+        self._view_cat_signatures: dict[str, tuple[int, int]] = {}
         self._breeding_cache: Optional[BreedingCache] = None
         self._cache_worker: Optional[BreedingCacheWorker] = None
         self._save_load_worker: Optional[SaveLoadWorker] = None
@@ -2098,6 +2099,16 @@ class MainWindow(QMainWindow):
         if hasattr(self, "_btn_furniture_view"):
             self._btn_furniture_view.setChecked(False)
 
+    def _set_view_cats_if_needed(self, view_key: str, view, cats: list[Cat]):
+        """Avoid recomputing heavy secondary views when the backing list did not change."""
+        if view is None:
+            return
+        signature = (id(cats), len(cats))
+        if self._view_cat_signatures.get(view_key) == signature:
+            return
+        view.set_cats(cats)
+        self._view_cat_signatures[view_key] = signature
+
     def _show_fight_club_view(self):
         if hasattr(self, "_btn_fight_club"):
             self._filter("__fight_club__", self._btn_fight_club)
@@ -2125,7 +2136,7 @@ class MainWindow(QMainWindow):
         if hasattr(self, "_furniture_view") and self._furniture_view is not None:
             self._furniture_view.hide()
         if self._tree_view is not None:
-            self._tree_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("tree", self._tree_view, self._cats)
             self._tree_view.show()
         if hasattr(self, "_btn_tree_view"):
             self._btn_tree_view.setChecked(True)
@@ -2168,7 +2179,7 @@ class MainWindow(QMainWindow):
             self._furniture_view.hide()
         if self._safe_breeding_view is not None:
             self._safe_breeding_view.set_quality_mode(self._safe_breeding_quality_mode, refresh=False)
-            self._safe_breeding_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, self._cats)
             self._safe_breeding_view.show()
         if hasattr(self, "_btn_tree_view"):
             self._btn_tree_view.setChecked(False)
@@ -2210,7 +2221,7 @@ class MainWindow(QMainWindow):
         if hasattr(self, "_furniture_view") and self._furniture_view is not None:
             self._furniture_view.hide()
         if self._breeding_partners_view is not None:
-            self._breeding_partners_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, self._cats)
             self._breeding_partners_view.show()
         if hasattr(self, "_btn_tree_view"):
             self._btn_tree_view.setChecked(False)
@@ -2252,7 +2263,7 @@ class MainWindow(QMainWindow):
         if hasattr(self, "_furniture_view") and self._furniture_view is not None:
             self._furniture_view.hide()
         if self._room_optimizer_view is not None:
-            self._room_optimizer_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, self._cats)
             self._room_optimizer_view.show()
         if hasattr(self, "_btn_tree_view"):
             self._btn_tree_view.setChecked(False)
@@ -2297,7 +2308,7 @@ class MainWindow(QMainWindow):
             self._perfect_planner_view.show()
             self._perfect_planner_view.set_loading_state(True)
             cats = list(self._cats)
-            QTimer.singleShot(0, lambda cats=cats: self._perfect_planner_view.set_cats(cats))
+            QTimer.singleShot(0, lambda cats=cats: self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, cats))
         if hasattr(self, "_btn_tree_view"):
             self._btn_tree_view.setChecked(False)
         if hasattr(self, "_btn_safe_breeding_view"):
@@ -2381,8 +2392,7 @@ class MainWindow(QMainWindow):
         if hasattr(self, "_furniture_view") and self._furniture_view is not None:
             self._furniture_view.hide()
         if self._mutation_planner_view is not None:
-            if self._mutation_planner_view._cats is not self._cats:
-                self._mutation_planner_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("mutation_planner", self._mutation_planner_view, self._cats)
             self._mutation_planner_view.show()
         if hasattr(self, "_btn_tree_view"):
             self._btn_tree_view.setChecked(False)
@@ -3021,13 +3031,13 @@ class MainWindow(QMainWindow):
         """Push tag-filtered cat list to secondary views."""
         filtered = self._tag_filtered_cats()
         if self._room_optimizer_view is not None:
-            self._room_optimizer_view.set_cats(filtered)
+            self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, filtered)
         if self._safe_breeding_view is not None:
-            self._safe_breeding_view.set_cats(filtered)
+            self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, filtered)
         if self._breeding_partners_view is not None:
-            self._breeding_partners_view.set_cats(filtered)
+            self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, filtered)
         if self._perfect_planner_view is not None:
-            self._perfect_planner_view.set_cats(filtered)
+            self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, filtered)
 
     def _clear_tag_filter(self):
         """Remove all tag filters."""
@@ -3055,15 +3065,15 @@ class MainWindow(QMainWindow):
             )
         if self._cats:
             if self._tree_view is not None and self._tree_view.isVisible():
-                self._tree_view.set_cats(self._cats)
+                self._set_view_cats_if_needed("tree", self._tree_view, self._cats)
             if self._safe_breeding_view is not None and self._safe_breeding_view.isVisible():
-                self._safe_breeding_view.set_cats(self._cats)
+                self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, self._cats)
             if self._breeding_partners_view is not None and self._breeding_partners_view.isVisible():
-                self._breeding_partners_view.set_cats(self._cats)
+                self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, self._cats)
             if self._room_optimizer_view is not None and self._room_optimizer_view.isVisible():
-                self._room_optimizer_view.set_cats(self._cats)
+                self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, self._cats)
             if self._perfect_planner_view is not None and self._perfect_planner_view.isVisible():
-                self._perfect_planner_view.set_cats(self._cats)
+                self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, self._cats)
             if self._calibration_view is not None and self._calibration_view.isVisible():
                 self._calibration_view.set_context(self._current_save, self._cats)
         # Repaint table without invalidating selection
@@ -3081,13 +3091,13 @@ class MainWindow(QMainWindow):
             _save_tags(self._current_save, self._cats)
         self._refresh_bulk_view_buttons()
         if self._safe_breeding_view is not None:
-            self._safe_breeding_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, self._cats)
         if self._breeding_partners_view is not None:
-            self._breeding_partners_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, self._cats)
         if self._room_optimizer_view is not None:
-            self._room_optimizer_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, self._cats)
         if self._perfect_planner_view is not None:
-            self._perfect_planner_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, self._cats)
 
     def _on_calibration_changed(self):
         if not self._current_save:
@@ -3096,13 +3106,13 @@ class MainWindow(QMainWindow):
         self._source_model.load(self._cats)
         self._refresh_filter_button_counts()
         if self._safe_breeding_view is not None:
-            self._safe_breeding_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, self._cats)
         if self._breeding_partners_view is not None:
-            self._breeding_partners_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, self._cats)
         if self._room_optimizer_view is not None:
-            self._room_optimizer_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, self._cats)
         if self._perfect_planner_view is not None:
-            self._perfect_planner_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, self._cats)
         if self._calibration_view is not None and self._calibration_view.isVisible():
             self._calibration_view.set_context(self._current_save, self._cats)
         self._update_count()
@@ -3366,15 +3376,15 @@ class MainWindow(QMainWindow):
             # Only push cats to currently visible views immediately.
             # Hidden views call set_cats themselves when shown via _show_* methods.
             if self._tree_view is not None and self._tree_view.isVisible():
-                self._tree_view.set_cats(cats)
+                self._set_view_cats_if_needed("tree", self._tree_view, cats)
             if self._safe_breeding_view is not None and self._safe_breeding_view.isVisible():
-                self._safe_breeding_view.set_cats(cats)
+                self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, cats)
             if self._breeding_partners_view is not None and self._breeding_partners_view.isVisible():
-                self._breeding_partners_view.set_cats(cats)
+                self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, cats)
             if self._room_optimizer_view is not None and self._room_optimizer_view.isVisible():
-                self._room_optimizer_view.set_cats(cats)
+                self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, cats)
             if self._perfect_planner_view is not None and self._perfect_planner_view.isVisible():
-                self._perfect_planner_view.set_cats(cats)
+                self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, cats)
             if self._calibration_view is not None and self._calibration_view.isVisible():
                 self._calibration_view.set_context(self._current_save, cats)
             self._sync_donation_planner_traits()
@@ -3700,15 +3710,15 @@ class MainWindow(QMainWindow):
         if self._furniture_view is not None:
             self._furniture_view.set_context(self._cats, self._furniture, self._furniture_data, available_rooms=self._available_house_rooms)
         if self._tree_view is not None and self._tree_view.isVisible():
-            self._tree_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("tree", self._tree_view, self._cats)
         if self._safe_breeding_view is not None and self._safe_breeding_view.isVisible():
-            self._safe_breeding_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, self._cats)
         if self._breeding_partners_view is not None and self._breeding_partners_view.isVisible():
-            self._breeding_partners_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, self._cats)
         if self._room_optimizer_view is not None and self._room_optimizer_view.isVisible():
-            self._room_optimizer_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, self._cats)
         if self._perfect_planner_view is not None and self._perfect_planner_view.isVisible():
-            self._perfect_planner_view.set_cats(self._cats)
+            self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, self._cats)
         if self._calibration_view is not None and self._calibration_view.isVisible():
             self._calibration_view.set_context(self._current_save, self._cats)
         self.statusBar().showMessage(_tr("status.rooms_refreshed", default="Room locations updated."))


### PR DESCRIPTION
### Motivation
- Repeatedly opening heavy secondary views was re-running expensive `set_cats(...)` work even when the backing cat list had not changed, making view switches feel sluggish; this change aims to make repeated opens much snappier.

### Description
- Added a per-view cat-list signature cache `self._view_cat_signatures` in `MainWindow` to track the last dataset pushed to each heavy view.
- Introduced `_set_view_cats_if_needed(view_key, view, cats)` which compares a lightweight signature `(id(cats), len(cats))` and calls `set_cats(...)` only when the signature differs.
- Replaced direct `set_cats(...)` calls in view-switch handlers and refresh paths (tree, safe breeding, breeding partners, room optimizer, perfect planner, mutation planner, tag-filter refresh, blacklist/calibration updates, save load, and quick room refresh) to route through the new helper.
- Preserved existing behavior when the list changes (different identity or length still triggers `set_cats`).

### Testing
- Ran `pytest tests/test_room_button_rebuild.py tests/test_perfect_planner_ui.py -q`, which failed during collection due to PySide6 import error (`libGL.so.1` missing) in this environment so GUI tests could not be executed.
- Ran `pytest tests/test_parser.py -q`, which executed the parser suite but reported 2 failures related to opening a test save (`sqlite3.OperationalError: unable to open database file` for `tools/saves/23.sav`) while the rest of the parser tests passed (90 passed, 2 skipped, 2 failed).
- Committed the change after local verification of code edits; further CI/GitHub runs on a full desktop/CI environment with OpenGL and test fixtures present should validate the GUI and parser test failures observed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69deed344ce0832aa988976e9036fe2d)