### PR TITLE
Fix race conditions and crashes during auto-refresh of save files

### DIFF
--- a/src/mewgenics/main_window.py
+++ b/src/mewgenics/main_window.py
@@ -270,6 +270,11 @@ class MainWindow(QMainWindow):
         self._cache_worker: Optional[BreedingCacheWorker] = None
         self._save_load_worker: Optional[SaveLoadWorker] = None
         self._quick_refresh_worker: Optional[QuickRoomRefreshWorker] = None
+        # Stale-signal discriminator for `_on_room_patch`.  See
+        # `_start_quick_room_refresh` for why `quit()/wait()` alone
+        # cannot prevent a previous worker's queued signal from
+        # clobbering freshly-loaded state.
+        self._quick_refresh_generation: int = 0
         self._prev_parent_keys: dict[int, tuple] = {}
         self._accessible_cat_keys: set[int] = set()
         self._fight_club_layout_active: bool = False
@@ -335,7 +340,18 @@ class MainWindow(QMainWindow):
         self.statusBar().addPermanentWidget(self._cache_progress)
 
         self._watcher = QFileSystemWatcher(self)
-        self._watcher.fileChanged.connect(self._on_file_changed)
+        self._watcher.fileChanged.connect(self._on_file_changed_raw)
+        # Debounce file-watcher events.  The game often writes the save
+        # in a burst (multiple fileChanged events within a few ms), and
+        # each one used to start its own QuickRoomRefreshWorker, racing
+        # with the previous one still running — a major contributor to
+        # the ~10% crash rate reported against v5.4.8.  Coalesce bursts
+        # into a single refresh 250 ms after the last event.
+        self._file_change_timer = QTimer(self)
+        self._file_change_timer.setSingleShot(True)
+        self._file_change_timer.setInterval(250)
+        self._file_change_timer.timeout.connect(self._on_file_changed_debounced)
+        self._pending_changed_path: Optional[str] = None
 
         # Use initial_save if provided; otherwise only auto-load the saved default when allowed.
         save_to_load = initial_save if initial_save else (_saved_default_save() if use_saved_default else None)
@@ -3414,14 +3430,10 @@ class MainWindow(QMainWindow):
             }
             return
 
-        # Cancel any in-progress worker
-        if self._cache_worker is not None:
-            worker = self._cache_worker
-            self._cache_worker = None
-            worker.quit()
-            if not worker.wait(500):
-                worker.terminate()
-                worker.wait(100)
+        # Supersede any in-progress cache worker rather than calling
+        # terminate().  The stale worker's phase1_ready / finished_cache
+        # slots drop the result by identity check (`is self._cache_worker`).
+        self._cache_worker = None
 
         # Snapshot parent keys before clearing old cache (for incremental update)
         prev_cache = self._breeding_cache if not force_full else None
@@ -3464,9 +3476,13 @@ class MainWindow(QMainWindow):
             parent=self,
         )
         worker.progress.connect(self._on_cache_progress)
-        worker.phase1_ready.connect(self._on_phase1_ready)
-        worker.finished_cache.connect(self._on_cache_ready)
-        worker.finished.connect(lambda: self._cache_progress.hide())
+        worker.phase1_ready.connect(
+            lambda cache, w=worker: self._on_phase1_ready(cache, source_worker=w)
+        )
+        worker.finished_cache.connect(
+            lambda cache, w=worker: self._on_cache_ready(cache, source_worker=w)
+        )
+        worker.finished.connect(lambda w=worker: self._cache_progress.hide() if w is self._cache_worker else None)
         self._cache_worker = worker
         worker.start()
 
@@ -3489,8 +3505,13 @@ class MainWindow(QMainWindow):
         else:
             self.statusBar().showMessage(_tr("status.cache_missing"))
 
-    def _on_phase1_ready(self, cache: BreedingCache):
+    def _on_phase1_ready(self, cache: BreedingCache, source_worker: Optional[BreedingCacheWorker] = None):
         """Ancestry computed — push to table and Mating Pair Search so they're usable immediately."""
+        # Drop results from superseded workers (a newer load_save has
+        # started).  Without this check, a stale cache would overwrite
+        # the fresh one currently being computed.
+        if source_worker is not None and source_worker is not self._cache_worker:
+            return
         self._breeding_cache = cache
         self._source_model.set_breeding_cache(cache)
         if self._safe_breeding_view is not None:
@@ -3503,7 +3524,9 @@ class MainWindow(QMainWindow):
             self._auto_scoring_view.set_cache(cache)
         self._cache_progress.setFormat(_tr("loading.cache.pair_risks"))
 
-    def _on_cache_ready(self, cache: BreedingCache):
+    def _on_cache_ready(self, cache: BreedingCache, source_worker: Optional[BreedingCacheWorker] = None):
+        if source_worker is not None and source_worker is not self._cache_worker:
+            return  # superseded — drop stale result
         self._breeding_cache = cache
         self._cache_worker = None
         self._cache_progress.hide()
@@ -3520,6 +3543,34 @@ class MainWindow(QMainWindow):
         self.statusBar().showMessage(
             self.statusBar().currentMessage() + _tr("status.cache_ready_suffix", default="  |  Breeding cache ready")
         )
+
+    def _on_save_load_failed(self, msg: str, source_worker: Optional[SaveLoadWorker] = None):
+        """Handle a SaveLoadWorker that raised during parsing.
+
+        The game writes the save atomically (temp file + rename) and the
+        watcher can fire during that brief window.  `SaveLoadWorker`
+        already retries with backoff; if it still fails, we surface the
+        error in the status bar and schedule a single self-healing retry
+        500 ms later — the next save the game writes almost always
+        resolves the condition.  Without this slot, the QThread would
+        die silently, the loading overlay would stay up forever, and
+        `_save_load_worker` would remain non-None so every subsequent
+        file-change event would cascade into `_reload()` hitting the
+        old `terminate()` path.
+        """
+        if source_worker is not None and source_worker is not self._save_load_worker:
+            return  # superseded — a newer load is already running
+        self._save_load_worker = None
+        self._loading_overlay.hide()
+        self.statusBar().showMessage(
+            _tr("status.save_load_failed",
+                default="Save load failed ({error}) — retrying in 500 ms.",
+                error=msg)
+        )
+        # Self-heal: try once more.  If the file is still mid-write we'll
+        # fail again and the user will see the status message; the next
+        # fileChanged event will re-trigger a refresh anyway.
+        QTimer.singleShot(500, self._reload)
 
     # ── Loading ────────────────────────────────────────────────────────────
 
@@ -3547,21 +3598,16 @@ class MainWindow(QMainWindow):
             self._watcher.removePaths(self._watcher.files())
         self._watcher.addPath(path)
 
-        # Cancel any in-progress load
-        if self._save_load_worker is not None:
-            worker = self._save_load_worker
-            self._save_load_worker = None
-            worker.quit()
-            if not worker.wait(500):
-                worker.terminate()
-                worker.wait(100)
-        if self._cache_worker is not None:
-            worker = self._cache_worker
-            self._cache_worker = None
-            worker.quit()
-            if not worker.wait(500):
-                worker.terminate()
-                worker.wait(100)
+        # Supersede any in-progress worker instead of calling terminate().
+        # QThread.terminate() mid-parse can leave the thread holding a
+        # SQLite handle or the GIL in an undefined state — a likely cause
+        # of the ~10% crash observed when the game rewrites the save
+        # while we're already loading it.  Drop the reference and let
+        # the old worker finish naturally; its finished_load / failed
+        # slots check `worker is self._save_load_worker` (identity) and
+        # discard stale results.
+        self._save_load_worker = None
+        self._cache_worker = None
 
         # Show overlay while parsing (background thread — main thread stays responsive for repaint)
         name = os.path.basename(path)
@@ -3575,12 +3621,24 @@ class MainWindow(QMainWindow):
 
         worker = SaveLoadWorker(path, parent=self)
         worker.finished_load.connect(
-            lambda result, force=force_full_breeding_cache: self._on_save_loaded(result, force)
+            lambda result, w=worker, force=force_full_breeding_cache:
+                self._on_save_loaded(result, force, source_worker=w)
+        )
+        worker.failed.connect(
+            lambda msg, w=worker: self._on_save_load_failed(msg, source_worker=w)
         )
         self._save_load_worker = worker
         worker.start()
 
-    def _on_save_loaded(self, result: dict, force_full_breeding_cache: bool = False):
+    def _on_save_loaded(self, result: dict, force_full_breeding_cache: bool = False,
+                        source_worker: Optional[SaveLoadWorker] = None):
+        # Drop results from superseded workers — a newer load_save has
+        # already started and points `_save_load_worker` at a different
+        # instance.  Processing this result would overwrite fresh state
+        # with stale data (or worse, if the stale worker managed to
+        # complete during a crash-repro reload storm).
+        if source_worker is not None and source_worker is not self._save_load_worker:
+            return
         self._save_load_worker = None
         # Dismiss overlay immediately — UI work below is fast (model.load is O(n), no ancestry)
         self._loading_overlay.hide()
@@ -3958,7 +4016,10 @@ class MainWindow(QMainWindow):
         if self._current_save:
             self.load_save(self._current_save)
 
-    def _on_file_changed(self, path: str):
+    def _on_file_changed_raw(self, path: str):
+        """Queue a debounced refresh so bursts of fileChanged events
+        (the game writes the save in rapid succession) collapse into a
+        single quick-refresh instead of spawning racing workers."""
         if path != self._current_save:
             return
         # Qt's QFileSystemWatcher stops watching a file after it's deleted
@@ -3970,6 +4031,16 @@ class MainWindow(QMainWindow):
             # Defer slightly: Qt sometimes fires fileChanged before the new
             # inode is fully materialised on NTFS, so addPath() fails silently.
             QTimer.singleShot(100, lambda p=path: self._rewatch_save(p))
+        self._pending_changed_path = path
+        # Restart the timer on every event so the debounce window
+        # resets after the latest burst write.
+        self._file_change_timer.start()
+
+    def _on_file_changed_debounced(self):
+        path = self._pending_changed_path
+        self._pending_changed_path = None
+        if path is None or path != self._current_save:
+            return
         # If cats are already loaded and no full reload is running, try the fast path.
         if self._cats and self._save_load_worker is None:
             self._start_quick_room_refresh()
@@ -3989,49 +4060,83 @@ class MainWindow(QMainWindow):
         self._watcher.addPath(path)
 
     def _start_quick_room_refresh(self):
-        if self._quick_refresh_worker is not None:
-            self._quick_refresh_worker.quit()
-            self._quick_refresh_worker.wait(200)
-            self._quick_refresh_worker = None
+        # We do NOT call quit()/wait() on the previous worker — doing so
+        # blocks the main thread and then still lets the old worker's
+        # queued room_patch signal fire after we've started a new one
+        # (see the "Vector 2" race in the fix plan).  Instead, bump the
+        # generation token so the old worker's signals are recognised as
+        # stale by `_on_room_patch` and silently dropped.  The old
+        # QThread finishes on its own and is reaped by Qt parent cleanup.
+        self._quick_refresh_generation += 1
+        gen = self._quick_refresh_generation
         expected = {c.db_key for c in self._cats}
-        w = QuickRoomRefreshWorker(self._current_save, expected, parent=self)
+        w = QuickRoomRefreshWorker(self._current_save, expected, generation=gen, parent=self)
         w.room_patch.connect(self._on_room_patch)
-        w.needs_full_reload.connect(self._reload)
+        w.needs_full_reload.connect(self._on_quick_refresh_needs_full_reload)
         self._quick_refresh_worker = w
         w.start()
 
-    def _on_room_patch(self, patch: dict):
+    def _on_quick_refresh_needs_full_reload(self, generation: int):
+        """Quick refresh fell back — do a full reload, but only if this
+        signal came from the current worker (stale ones are ignored)."""
+        if generation != self._quick_refresh_generation:
+            return
+        self._reload()
+
+    def _on_room_patch(self, generation: int, patch: dict):
+        # Drop signals from superseded workers.  Without this guard, a
+        # stale worker's room_patch can fire after the next refresh has
+        # already mutated `self._cats` or `_rebuild_room_buttons()` has
+        # deleteLater()'d its widgets — either path risks a crash.
+        if generation != self._quick_refresh_generation:
+            return
         self._quick_refresh_worker = None
-        for cat in self._cats:
-            entry = patch.get(cat.db_key)
-            if entry is not None:
-                cat.room, cat.status = entry
-        # Lightweight repaint — no model rebuild, no ancestry recompute.
-        # layoutChanged updates cell data but doesn't re-run filterAcceptsRow
-        # in QSortFilterProxyModel, so cats that moved rooms would remain
-        # visible under the old room filter.  invalidate() re-filters + re-sorts.
-        self._source_model.layoutChanged.emit()
-        self._proxy_model.invalidate()
-        self._rebuild_room_buttons(self._cats)
-        self._refresh_filter_button_counts()
-        self._bump_cats_generation()
-        if self._furniture_view is not None:
-            self._furniture_view.set_context(self._cats, self._furniture, self._furniture_data, available_rooms=self._available_house_rooms)
-            self._view_generation["furniture"] = self._cats_generation
-        if self._tree_view is not None and self._tree_view.isVisible():
-            self._set_view_cats_if_needed("tree", self._tree_view, self._cats)
-        if self._safe_breeding_view is not None and self._safe_breeding_view.isVisible():
-            self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, self._cats)
-        if self._breeding_partners_view is not None and self._breeding_partners_view.isVisible():
-            self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, self._cats)
-        if self._room_optimizer_view is not None and self._room_optimizer_view.isVisible():
-            self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, self._cats)
-        if self._perfect_planner_view is not None and self._perfect_planner_view.isVisible():
-            self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, self._cats)
-        if self._calibration_view is not None and self._calibration_view.isVisible():
-            self._calibration_view.set_context(self._current_save, self._cats)
-            self._view_generation["calibration"] = self._cats_generation
-        self.statusBar().showMessage(_tr("status.rooms_refreshed", default="Room locations updated."))
+        # Wrap the whole body in try/except: unlike `_on_save_loaded`,
+        # this slot used to run bare, so any Qt-object-lifetime or view
+        # bookkeeping error propagated to the event loop and aborted the
+        # app.  On failure, log to the status bar and fall back to a
+        # full reload — the user-visible symptom is a brief flicker
+        # instead of a crash.
+        try:
+            for cat in self._cats:
+                entry = patch.get(cat.db_key)
+                if entry is not None:
+                    cat.room, cat.status = entry
+            # Lightweight repaint — no model rebuild, no ancestry recompute.
+            # layoutChanged updates cell data but doesn't re-run filterAcceptsRow
+            # in QSortFilterProxyModel, so cats that moved rooms would remain
+            # visible under the old room filter.  invalidate() re-filters + re-sorts.
+            self._source_model.layoutChanged.emit()
+            self._proxy_model.invalidate()
+            self._rebuild_room_buttons(self._cats)
+            self._refresh_filter_button_counts()
+            self._bump_cats_generation()
+            if self._furniture_view is not None:
+                self._furniture_view.set_context(self._cats, self._furniture, self._furniture_data, available_rooms=self._available_house_rooms)
+                self._view_generation["furniture"] = self._cats_generation
+            if self._tree_view is not None and self._tree_view.isVisible():
+                self._set_view_cats_if_needed("tree", self._tree_view, self._cats)
+            if self._safe_breeding_view is not None and self._safe_breeding_view.isVisible():
+                self._set_view_cats_if_needed("safe_breeding", self._safe_breeding_view, self._cats)
+            if self._breeding_partners_view is not None and self._breeding_partners_view.isVisible():
+                self._set_view_cats_if_needed("breeding_partners", self._breeding_partners_view, self._cats)
+            if self._room_optimizer_view is not None and self._room_optimizer_view.isVisible():
+                self._set_view_cats_if_needed("room_optimizer", self._room_optimizer_view, self._cats)
+            if self._perfect_planner_view is not None and self._perfect_planner_view.isVisible():
+                self._set_view_cats_if_needed("perfect_planner", self._perfect_planner_view, self._cats)
+            if self._calibration_view is not None and self._calibration_view.isVisible():
+                self._calibration_view.set_context(self._current_save, self._cats)
+                self._view_generation["calibration"] = self._cats_generation
+            self.statusBar().showMessage(_tr("status.rooms_refreshed", default="Room locations updated."))
+        except Exception as exc:  # noqa: BLE001 — last line of defence before the event loop
+            self.statusBar().showMessage(
+                _tr("status.quick_refresh_failed",
+                    default="Quick refresh failed ({error}) — reloading save.",
+                    error=repr(exc))
+            )
+            # Full reload regenerates all widgets from scratch, clearing
+            # any dangling references that caused the failure.
+            QTimer.singleShot(0, self._reload)
 
     def _open_tree_browser(self):
         self._push_nav_history()

--- a/src/mewgenics/main_window.py
+++ b/src/mewgenics/main_window.py
@@ -133,6 +133,11 @@ from mewgenics.utils.paths import _scoring_path
 
 
 class MainWindow(QMainWindow):
+    # Max consecutive self-heal retries after a transient save-load failure.
+    # After this, we stop and wait for a fresh fileChanged event (or manual
+    # reload) rather than spinning on a permanently-broken save.
+    _SAVE_LOAD_RETRY_CAP = 3
+
     @staticmethod
     def _set_bulk_toggle_label(btn: QPushButton, label: str, enabled: bool):
         btn.setText(_tr("bulk.label_template", label=label, state=_tr("common.on" if enabled else "common.off")))
@@ -269,6 +274,9 @@ class MainWindow(QMainWindow):
         self._breeding_cache: Optional[BreedingCache] = None
         self._cache_worker: Optional[BreedingCacheWorker] = None
         self._save_load_worker: Optional[SaveLoadWorker] = None
+        # Consecutive self-heal attempts triggered by `_on_save_load_failed`.
+        # Capped so a permanently broken save can't loop forever.
+        self._save_load_retries: int = 0
         self._quick_refresh_worker: Optional[QuickRoomRefreshWorker] = None
         # Stale-signal discriminator for `_on_room_patch`.  See
         # `_start_quick_room_refresh` for why `quit()/wait()` alone
@@ -3544,33 +3552,37 @@ class MainWindow(QMainWindow):
             self.statusBar().currentMessage() + _tr("status.cache_ready_suffix", default="  |  Breeding cache ready")
         )
 
-    def _on_save_load_failed(self, msg: str, source_worker: Optional[SaveLoadWorker] = None):
+    def _on_save_load_failed(self, msg: str, is_transient: bool = True,
+                              source_worker: Optional[SaveLoadWorker] = None):
         """Handle a SaveLoadWorker that raised during parsing.
 
-        The game writes the save atomically (temp file + rename) and the
-        watcher can fire during that brief window.  `SaveLoadWorker`
-        already retries with backoff; if it still fails, we surface the
-        error in the status bar and schedule a single self-healing retry
-        500 ms later — the next save the game writes almost always
-        resolves the condition.  Without this slot, the QThread would
-        die silently, the loading overlay would stay up forever, and
-        `_save_load_worker` would remain non-None so every subsequent
-        file-change event would cascade into `_reload()` hitting the
-        old `terminate()` path.
+        Only schedule a self-heal reload for transient I/O errors — a
+        permanently broken save (corrupt file, parser bug, KeyError, etc.)
+        must not spin the retry timer forever.  The next `fileChanged`
+        event will re-trigger a load naturally if the game fixes the
+        condition by writing a fresh save.
         """
         if source_worker is not None and source_worker is not self._save_load_worker:
             return  # superseded — a newer load is already running
         self._save_load_worker = None
         self._loading_overlay.hide()
-        self.statusBar().showMessage(
-            _tr("status.save_load_failed",
-                default="Save load failed ({error}) — retrying in 500 ms.",
-                error=msg)
-        )
-        # Self-heal: try once more.  If the file is still mid-write we'll
-        # fail again and the user will see the status message; the next
-        # fileChanged event will re-trigger a refresh anyway.
-        QTimer.singleShot(500, self._reload)
+        if is_transient and self._save_load_retries < self._SAVE_LOAD_RETRY_CAP:
+            self._save_load_retries += 1
+            self.statusBar().showMessage(
+                _tr("status.save_load_failed",
+                    default="Save load failed ({error}) — retrying in 500 ms.",
+                    error=msg)
+            )
+            QTimer.singleShot(500, self._reload)
+        else:
+            # Permanent failure or retry budget exhausted.  Leave the
+            # error visible and let a fresh fileChanged event (or a
+            # manual reload) reset the counter on success.
+            self.statusBar().showMessage(
+                _tr("status.save_load_failed_permanent",
+                    default="Save load failed ({error}). Open a different save or fix the file.",
+                    error=msg)
+            )
 
     # ── Loading ────────────────────────────────────────────────────────────
 
@@ -3625,7 +3637,8 @@ class MainWindow(QMainWindow):
                 self._on_save_loaded(result, force, source_worker=w)
         )
         worker.failed.connect(
-            lambda msg, w=worker: self._on_save_load_failed(msg, source_worker=w)
+            lambda msg, transient, w=worker:
+                self._on_save_load_failed(msg, transient, source_worker=w)
         )
         self._save_load_worker = worker
         worker.start()
@@ -3640,6 +3653,7 @@ class MainWindow(QMainWindow):
         if source_worker is not None and source_worker is not self._save_load_worker:
             return
         self._save_load_worker = None
+        self._save_load_retries = 0  # success resets the self-heal counter
         # Dismiss overlay immediately — UI work below is fast (model.load is O(n), no ancestry)
         self._loading_overlay.hide()
         self._save_view_disabled = True

--- a/src/mewgenics/utils/retry.py
+++ b/src/mewgenics/utils/retry.py
@@ -1,0 +1,44 @@
+"""Retry-with-backoff helper for transient save-file I/O failures.
+
+The game rewrites the `.sav` atomically (temp file + rename).
+`QFileSystemWatcher` fires on the rename but SQLite / LZ4 / low-level
+file I/O can briefly see the file as locked, missing, or truncated.
+Retrying a handful of times with short backoff turns those transient
+failures into automatic recovery instead of a user-visible crash.
+"""
+import sqlite3
+import time
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+# Exceptions caused by the partial-write window — retryable.  Anything
+# outside this tuple (TypeError, AttributeError, KeyError, …) indicates
+# a real bug or a genuinely corrupted save, so propagate immediately
+# rather than wasting ~350 ms re-running an expensive parse that will
+# re-allocate hundreds of MB for nothing.
+_TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    sqlite3.OperationalError,  # "database is locked", "disk I/O error", "unable to open"
+    sqlite3.DatabaseError,     # malformed header / truncated file
+    OSError,                   # file momentarily missing, NTFS rename blip
+    EOFError,                  # truncated binary read mid-rename
+)
+
+_DEFAULT_DELAYS_MS = (50, 100, 200)
+
+
+def retry_transient(func: Callable[[], T], delays_ms=_DEFAULT_DELAYS_MS) -> T:
+    """Call `func()`, retrying up to len(delays_ms) times on transient I/O errors.
+
+    Delays are applied *between* attempts, so len(delays_ms)+1 total attempts.
+    Non-transient exceptions propagate on the first failure.
+    """
+    total_attempts = len(delays_ms) + 1
+    for attempt in range(total_attempts):
+        try:
+            return func()
+        except _TRANSIENT_EXCEPTIONS:
+            if attempt + 1 >= total_attempts:
+                raise
+            time.sleep(delays_ms[attempt] / 1000.0)

--- a/src/mewgenics/utils/retry.py
+++ b/src/mewgenics/utils/retry.py
@@ -18,7 +18,7 @@ T = TypeVar("T")
 # a real bug or a genuinely corrupted save, so propagate immediately
 # rather than wasting ~350 ms re-running an expensive parse that will
 # re-allocate hundreds of MB for nothing.
-_TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     sqlite3.OperationalError,  # "database is locked", "disk I/O error", "unable to open"
     sqlite3.DatabaseError,     # malformed header / truncated file
     OSError,                   # file momentarily missing, NTFS rename blip
@@ -38,7 +38,7 @@ def retry_transient(func: Callable[[], T], delays_ms=_DEFAULT_DELAYS_MS) -> T:
     for attempt in range(total_attempts):
         try:
             return func()
-        except _TRANSIENT_EXCEPTIONS:
+        except TRANSIENT_EXCEPTIONS:
             if attempt + 1 >= total_attempts:
                 raise
             time.sleep(delays_ms[attempt] / 1000.0)

--- a/src/mewgenics/workers/room_refresh.py
+++ b/src/mewgenics/workers/room_refresh.py
@@ -4,6 +4,7 @@ import sqlite3
 from PySide6.QtCore import QThread, Signal
 
 from save_parser import _get_house_info, _get_adventure_keys
+from mewgenics.utils.retry import retry_transient
 
 
 class QuickRoomRefreshWorker(QThread):
@@ -11,26 +12,51 @@ class QuickRoomRefreshWorker(QThread):
 
     If the set of cat keys in the DB has changed (birth/death), emits needs_full_reload
     instead so the caller can fall back to a full SaveLoadWorker parse.
-    """
-    room_patch = Signal(object)      # dict[int, tuple[str, str]]  db_key → (room, status)
-    needs_full_reload = Signal()
 
-    def __init__(self, path: str, expected_keys: set, parent=None):
+    A *generation* token is passed through and re-emitted alongside the
+    result.  MainWindow compares that token against its current generation
+    to discard signals from superseded workers — preventing a stale
+    room_patch from clobbering freshly-loaded state.
+    """
+    # (generation, patch dict)  db_key → (room, status)
+    room_patch = Signal(int, object)
+    needs_full_reload = Signal(int)
+
+    def __init__(self, path: str, expected_keys: set, generation: int = 0, parent=None):
         super().__init__(parent)
         self._path = path
         self._expected_keys = expected_keys
+        self._generation = generation
 
-    def run(self):
+    def _read_state(self):
+        """Open the save read-only and return (live_keys, house, adv).
+
+        Raises the underlying sqlite3 exception if the file can't be opened
+        or queried — retry_transient handles the partial-write window.
+        """
+        conn = None
         try:
             conn = sqlite3.connect(f"file:{self._path}?mode=ro", uri=True)
             live_keys = {row[0] for row in conn.execute("SELECT key FROM cats").fetchall()}
-            if live_keys != self._expected_keys:
-                conn.close()
-                self.needs_full_reload.emit()
-                return
             house = _get_house_info(conn)
             adv = _get_adventure_keys(conn)
-            conn.close()
+            return live_keys, house, adv
+        finally:
+            if conn is not None:
+                # close() can raise if the connection is already broken
+                # by the error we're unwinding — swallow so we don't mask
+                # the real exception.
+                try:
+                    conn.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+    def run(self):
+        try:
+            live_keys, house, adv = retry_transient(self._read_state)
+            if live_keys != self._expected_keys:
+                self.needs_full_reload.emit(self._generation)
+                return
             patch: dict[int, tuple[str, str]] = {}
             for key in live_keys:
                 if key in adv:
@@ -39,6 +65,6 @@ class QuickRoomRefreshWorker(QThread):
                     patch[key] = (house[key], "In House")
                 else:
                     patch[key] = ("", "Gone")
-            self.room_patch.emit(patch)
+            self.room_patch.emit(self._generation, patch)
         except Exception:
-            self.needs_full_reload.emit()
+            self.needs_full_reload.emit(self._generation)

--- a/src/mewgenics/workers/save_loader.py
+++ b/src/mewgenics/workers/save_loader.py
@@ -6,39 +6,53 @@ from mewgenics.utils.cat_persistence import (
     _load_blacklist, _load_must_breed, _load_pinned, _load_tags,
 )
 from mewgenics.utils.calibration import _load_gender_overrides, _apply_calibration
+from mewgenics.utils.retry import retry_transient
 
 
 class SaveLoadWorker(QThread):
     """Parses a save file off the main thread so the UI stays responsive."""
     status = Signal(str)  # status text updates
     finished_load = Signal(object)  # emits dict with parsed results
+    failed = Signal(str)  # emits an error string if parsing fails
 
     def __init__(self, path: str, parent=None):
         super().__init__(parent)
         self._path = path
 
     def run(self):
-        self.status.emit("Parsing save file…")
-        save = parse_save(self._path)
-        cats, errors, unlocked_house_rooms = save
-        self.status.emit("Loading blacklist & overrides…")
-        _load_blacklist(self._path, cats)
-        _load_must_breed(self._path, cats)
-        _load_pinned(self._path, cats)
-        _load_tags(self._path, cats)
-        applied_overrides, override_rows = _load_gender_overrides(self._path, cats)
-        cal_explicit, cal_token, cal_rows = _apply_calibration(self._path, cats)
-        self.finished_load.emit({
-            "cats": cats,
-            "errors": errors,
-            "unlocked_house_rooms": unlocked_house_rooms,
-            "accessible_cats": save.accessible_cats,
-            "furniture": save.furniture,
-            "furniture_by_room": save.furniture_by_room,
-            "pedigree_coi_memos": save.pedigree_coi_memos,
-            "applied_overrides": applied_overrides,
-            "override_rows": override_rows,
-            "cal_explicit": cal_explicit,
-            "cal_token": cal_token,
-            "cal_rows": cal_rows,
-        })
+        try:
+            self.status.emit("Parsing save file…")
+            # retry_transient recovers from the partial-write window the
+            # game briefly opens when it renames its temp save over the
+            # real file.  Non-transient errors (corrupt saves, missing
+            # file, etc.) propagate immediately.
+            save = retry_transient(lambda: parse_save(self._path))
+            cats, errors, unlocked_house_rooms = save
+            self.status.emit("Loading blacklist & overrides…")
+            _load_blacklist(self._path, cats)
+            _load_must_breed(self._path, cats)
+            _load_pinned(self._path, cats)
+            _load_tags(self._path, cats)
+            applied_overrides, override_rows = _load_gender_overrides(self._path, cats)
+            cal_explicit, cal_token, cal_rows = _apply_calibration(self._path, cats)
+            self.finished_load.emit({
+                "cats": cats,
+                "errors": errors,
+                "unlocked_house_rooms": unlocked_house_rooms,
+                "accessible_cats": save.accessible_cats,
+                "furniture": save.furniture,
+                "furniture_by_room": save.furniture_by_room,
+                "pedigree_coi_memos": save.pedigree_coi_memos,
+                "applied_overrides": applied_overrides,
+                "override_rows": override_rows,
+                "cal_explicit": cal_explicit,
+                "cal_token": cal_token,
+                "cal_rows": cal_rows,
+            })
+        except Exception as exc:  # noqa: BLE001 — last line of defence before QThread dies silently
+            # Without this, an unhandled exception would kill the QThread,
+            # `finished_load` would never fire, the loading overlay would
+            # stay up, and `_save_load_worker` on MainWindow would remain
+            # non-None — so every subsequent file-change event would
+            # cascade into the old terminate() path.
+            self.failed.emit(repr(exc))

--- a/src/mewgenics/workers/save_loader.py
+++ b/src/mewgenics/workers/save_loader.py
@@ -6,14 +6,16 @@ from mewgenics.utils.cat_persistence import (
     _load_blacklist, _load_must_breed, _load_pinned, _load_tags,
 )
 from mewgenics.utils.calibration import _load_gender_overrides, _apply_calibration
-from mewgenics.utils.retry import retry_transient
+from mewgenics.utils.retry import retry_transient, TRANSIENT_EXCEPTIONS
 
 
 class SaveLoadWorker(QThread):
     """Parses a save file off the main thread so the UI stays responsive."""
     status = Signal(str)  # status text updates
     finished_load = Signal(object)  # emits dict with parsed results
-    failed = Signal(str)  # emits an error string if parsing fails
+    # (error_repr, is_transient) — is_transient distinguishes partial-write
+    # races (worth a self-heal retry) from real errors (don't retry-loop).
+    failed = Signal(str, bool)
 
     def __init__(self, path: str, parent=None):
         super().__init__(parent)
@@ -55,4 +57,4 @@ class SaveLoadWorker(QThread):
             # stay up, and `_save_load_worker` on MainWindow would remain
             # non-None — so every subsequent file-change event would
             # cascade into the old terminate() path.
-            self.failed.emit(repr(exc))
+            self.failed.emit(repr(exc), isinstance(exc, TRANSIENT_EXCEPTIONS))

--- a/tests/test_game_update_crash_fixes.py
+++ b/tests/test_game_update_crash_fixes.py
@@ -114,16 +114,18 @@ class TestSaveLoadWorkerFailedSignal:
         """
         worker = SaveLoadWorker(str(tmp_path / "nope.sav"))
         finished_results = []
-        failed_messages = []
+        failed_events = []
         worker.finished_load.connect(finished_results.append)
-        worker.failed.connect(failed_messages.append)
+        worker.failed.connect(lambda msg, transient: failed_events.append((msg, transient)))
 
         _run_thread_to_completion(worker)
 
         assert finished_results == []
-        assert len(failed_messages) == 1
-        # Caller can see what went wrong.
-        assert failed_messages[0]  # non-empty repr
+        assert len(failed_events) == 1
+        msg, is_transient = failed_events[0]
+        assert msg  # non-empty repr
+        # A missing file surfaces as OSError/FileNotFoundError → transient.
+        assert is_transient is True
 
     def test_retry_with_backoff_recovers_from_transient_failure(
         self, qt_app, tmp_path, monkeypatch
@@ -184,6 +186,97 @@ class TestSaveLoadWorkerFailedSignal:
         assert failed == [], f"worker should have recovered, got failure {failed!r}"
         assert len(finished) == 1
         assert attempts["n"] == 2  # one failed, one succeeded
+
+    def test_non_transient_parse_failure_is_flagged_not_transient(
+        self, qt_app, tmp_path, monkeypatch
+    ):
+        """Corrupt saves / parser bugs raise TypeError/KeyError etc.
+        Those must be reported with is_transient=False so the main window
+        can skip the self-heal retry timer and avoid a busy-loop.
+        """
+        path = tmp_path / "fake.sav"
+        path.touch()
+
+        def busted_parse(p):
+            raise KeyError("missing field — real bug, do not retry")
+
+        monkeypatch.setattr(save_loader_module, "parse_save", busted_parse)
+
+        worker = SaveLoadWorker(str(path))
+        failed_events = []
+        worker.failed.connect(lambda msg, transient: failed_events.append((msg, transient)))
+
+        _run_thread_to_completion(worker)
+
+        assert len(failed_events) == 1
+        _, is_transient = failed_events[0]
+        assert is_transient is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# P1: _on_save_load_failed caps retries so a permanently-broken save
+#     cannot spin a self-heal loop forever.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestSaveLoadFailureRetryPolicy:
+    def _bare_window(self):
+        window = main_window_module.MainWindow.__new__(main_window_module.MainWindow)
+        window._save_load_worker = None
+        window._save_load_retries = 0
+        window._loading_overlay = SimpleNamespace(hide=lambda: None)
+        window.statusBar = lambda: SimpleNamespace(showMessage=lambda *a, **k: None)
+        return window
+
+    def test_non_transient_failure_does_not_schedule_retry(self, qt_app):
+        window = self._bare_window()
+        scheduled = []
+        with patch.object(main_window_module, "QTimer") as qt:
+            qt.singleShot = lambda ms, fn: scheduled.append((ms, fn))
+            main_window_module.MainWindow._on_save_load_failed(
+                window, "KeyError('foo')", False
+            )
+        assert scheduled == []
+        assert window._save_load_retries == 0  # no increment on permanent error
+
+    def test_transient_failure_under_cap_schedules_retry(self, qt_app):
+        window = self._bare_window()
+        scheduled = []
+        with patch.object(main_window_module, "QTimer") as qt:
+            qt.singleShot = lambda ms, fn: scheduled.append((ms, fn))
+            main_window_module.MainWindow._on_save_load_failed(
+                window, "OperationalError('locked')", True
+            )
+        assert len(scheduled) == 1
+        assert scheduled[0][0] == 500
+        assert window._save_load_retries == 1
+
+    def test_transient_failure_at_cap_stops_retrying(self, qt_app):
+        window = self._bare_window()
+        window._save_load_retries = main_window_module.MainWindow._SAVE_LOAD_RETRY_CAP
+        scheduled = []
+        with patch.object(main_window_module, "QTimer") as qt:
+            qt.singleShot = lambda ms, fn: scheduled.append((ms, fn))
+            main_window_module.MainWindow._on_save_load_failed(
+                window, "OperationalError('locked')", True
+            )
+        assert scheduled == [], "retry cap must stop the self-heal loop"
+        # Cap is sticky until a successful load resets it.
+        assert window._save_load_retries == main_window_module.MainWindow._SAVE_LOAD_RETRY_CAP
+
+    def test_superseded_worker_does_not_advance_retry_counter(self, qt_app):
+        window = self._bare_window()
+        window._save_load_worker = SimpleNamespace(name="current")
+        stale = SimpleNamespace(name="stale")
+        with patch.object(main_window_module, "QTimer") as qt:
+            scheduled = []
+            qt.singleShot = lambda ms, fn: scheduled.append((ms, fn))
+            main_window_module.MainWindow._on_save_load_failed(
+                window, "OperationalError('locked')", True, source_worker=stale
+            )
+        assert scheduled == []
+        assert window._save_load_retries == 0
+        assert window._save_load_worker is not None  # current worker untouched
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_game_update_crash_fixes.py
+++ b/tests/test_game_update_crash_fixes.py
@@ -1,0 +1,446 @@
+"""Regression tests for the v5.4.8 auto-refresh crash.
+
+When the game rewrote its save while the manager was open, the manager
+crashed roughly 10% of the time.  The fixes in this branch close four
+race / exception-handling gaps:
+
+  F1/F6  SaveLoadWorker catches parse failures and retries partial
+          writes, emitting `failed` instead of letting the QThread die.
+  F3     QuickRoomRefreshWorker tags every signal with a generation
+          token; MainWindow._on_room_patch drops stale signals.
+  F4     load_save no longer calls QThread.terminate() on in-flight
+          SaveLoadWorkers — a superseded worker's result is discarded
+          by identity check in _on_save_loaded instead.
+  F5     QFileSystemWatcher events are debounced with a 250 ms timer.
+
+These tests verify each fix in isolation without needing a real save.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+
+_proj_root = Path(__file__).resolve().parents[1]
+_src_dir = _proj_root / "src"
+sys.path.insert(0, str(_src_dir))
+sys.path.insert(0, str(_proj_root))
+
+from PySide6.QtCore import QEventLoop, QTimer
+from PySide6.QtWidgets import QApplication
+
+from mewgenics.workers.save_loader import SaveLoadWorker
+from mewgenics.workers.room_refresh import QuickRoomRefreshWorker
+from mewgenics.utils.retry import retry_transient
+import mewgenics.main_window as main_window_module
+import mewgenics.workers.save_loader as save_loader_module
+import mewgenics.workers.room_refresh as room_refresh_module
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def _run_thread_to_completion(thread, timeout_ms: int = 5000):
+    """Start a QThread, pump events until it finishes, then join."""
+    loop = QEventLoop()
+    thread.finished.connect(loop.quit)
+    # Safety kill-switch in case the worker hangs.
+    killer = QTimer()
+    killer.setSingleShot(True)
+    killer.timeout.connect(loop.quit)
+    killer.start(timeout_ms)
+    thread.start()
+    loop.exec()
+    assert thread.wait(timeout_ms), "worker did not finish in time"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# retry_transient: only retries transient I/O errors, not real bugs
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestRetryTransient:
+    def test_non_transient_exception_propagates_without_retry(self):
+        """TypeError / ValueError / AttributeError etc. are real bugs
+        or genuinely corrupted data — they must NOT trigger the retry
+        loop, which would waste ~350 ms re-running a doomed operation
+        (and for parse_save, re-allocate hundreds of MB)."""
+        calls = {"n": 0}
+
+        def always_type_error():
+            calls["n"] += 1
+            raise TypeError("real bug — should not retry")
+
+        with pytest.raises(TypeError):
+            retry_transient(always_type_error)
+
+        assert calls["n"] == 1  # called once, never retried
+
+    def test_transient_exception_retries(self):
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return "ok"
+
+        assert retry_transient(flaky, delays_ms=(1, 1, 1)) == "ok"
+        assert calls["n"] == 3
+
+
+# ─────────────────────────────────────────────────────────────────────
+# F1: SaveLoadWorker emits `failed` instead of dying silently
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestSaveLoadWorkerFailedSignal:
+    def test_nonexistent_path_emits_failed_not_finished(self, qt_app, tmp_path):
+        """A missing .sav used to let parse_save raise, killing the
+        QThread silently.  Now it must emit `failed` and leave
+        `finished_load` quiet so MainWindow can recover.
+        """
+        worker = SaveLoadWorker(str(tmp_path / "nope.sav"))
+        finished_results = []
+        failed_messages = []
+        worker.finished_load.connect(finished_results.append)
+        worker.failed.connect(failed_messages.append)
+
+        _run_thread_to_completion(worker)
+
+        assert finished_results == []
+        assert len(failed_messages) == 1
+        # Caller can see what went wrong.
+        assert failed_messages[0]  # non-empty repr
+
+    def test_retry_with_backoff_recovers_from_transient_failure(
+        self, qt_app, tmp_path, monkeypatch
+    ):
+        """Partial writes fail once then succeed.  With 3 retries the
+        worker must recover automatically and emit `finished_load`.
+        """
+        path = tmp_path / "fake.sav"
+        path.touch()
+
+        attempts = {"n": 0}
+
+        def flaky_parse(p):
+            attempts["n"] += 1
+            if attempts["n"] < 2:
+                raise sqlite3.OperationalError("database is locked")
+            # Pretend a successful parse returned the minimum shape the
+            # worker unpacks + the attrs it forwards.
+            cats = []
+            save = SimpleNamespace(
+                accessible_cats=set(),
+                furniture=[],
+                furniture_by_room={},
+                pedigree_coi_memos={},
+            )
+            # The worker does `cats, errors, unlocked = save` so the
+            # top-level return must be a 3-tuple but still expose the
+            # extra attrs above.  Use a small shim class.
+            class _Shim(tuple):
+                def __new__(cls, items, extras):
+                    self = super().__new__(cls, items)
+                    self.__dict__.update(extras)
+                    return self
+            return _Shim((cats, [], []), save.__dict__)
+
+        monkeypatch.setattr(save_loader_module, "parse_save", flaky_parse)
+        # Stub out the sidecar-file loaders — they'd otherwise try to
+        # open JSONs next to the fake save.
+        monkeypatch.setattr(save_loader_module, "_load_blacklist", lambda *a, **k: None)
+        monkeypatch.setattr(save_loader_module, "_load_must_breed", lambda *a, **k: None)
+        monkeypatch.setattr(save_loader_module, "_load_pinned", lambda *a, **k: None)
+        monkeypatch.setattr(save_loader_module, "_load_tags", lambda *a, **k: None)
+        monkeypatch.setattr(
+            save_loader_module, "_load_gender_overrides", lambda *a, **k: (None, [])
+        )
+        monkeypatch.setattr(
+            save_loader_module, "_apply_calibration", lambda *a, **k: (False, None, [])
+        )
+
+        worker = SaveLoadWorker(str(path))
+        finished = []
+        failed = []
+        worker.finished_load.connect(finished.append)
+        worker.failed.connect(failed.append)
+
+        _run_thread_to_completion(worker)
+
+        assert failed == [], f"worker should have recovered, got failure {failed!r}"
+        assert len(finished) == 1
+        assert attempts["n"] == 2  # one failed, one succeeded
+
+
+# ─────────────────────────────────────────────────────────────────────
+# F6: QuickRoomRefreshWorker retry on transient sqlite failure
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestQuickRefreshRetry:
+    def test_sqlite_locked_once_then_succeeds(self, qt_app, tmp_path, monkeypatch):
+        """If sqlite3.connect raises `database is locked` once, the
+        worker must retry and recover rather than falling through to
+        `needs_full_reload`.
+        """
+        path = tmp_path / "fake.sav"
+        path.touch()
+
+        attempts = {"n": 0}
+        real_connect = sqlite3.connect
+
+        class _FakeConn:
+            def execute(self, _sql):
+                return SimpleNamespace(fetchall=lambda: [(1,), (2,)])
+
+            def close(self):
+                pass
+
+        def flaky_connect(*args, **kw):
+            attempts["n"] += 1
+            if attempts["n"] < 2:
+                raise sqlite3.OperationalError("database is locked")
+            return _FakeConn()
+
+        monkeypatch.setattr(room_refresh_module.sqlite3, "connect", flaky_connect)
+        monkeypatch.setattr(
+            room_refresh_module, "_get_house_info", lambda conn: {1: "Attic", 2: "Floor1_Large"}
+        )
+        monkeypatch.setattr(
+            room_refresh_module, "_get_adventure_keys", lambda conn: set()
+        )
+
+        worker = QuickRoomRefreshWorker(str(path), expected_keys={1, 2}, generation=7)
+        patches = []
+        fallbacks = []
+        worker.room_patch.connect(lambda gen, patch: patches.append((gen, patch)))
+        worker.needs_full_reload.connect(fallbacks.append)
+
+        _run_thread_to_completion(worker)
+
+        assert fallbacks == [], "transient failure should have recovered"
+        assert len(patches) == 1
+        gen, patch = patches[0]
+        assert gen == 7  # generation token round-tripped
+        assert patch == {1: ("Attic", "In House"), 2: ("Floor1_Large", "In House")}
+        assert attempts["n"] == 2
+
+    def test_exhausted_retries_fall_back_to_full_reload(self, qt_app, tmp_path, monkeypatch):
+        path = tmp_path / "fake.sav"
+        path.touch()
+
+        def always_fail(uri, **kw):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(room_refresh_module.sqlite3, "connect", always_fail)
+
+        worker = QuickRoomRefreshWorker(str(path), expected_keys=set(), generation=3)
+        patches = []
+        fallbacks = []
+        worker.room_patch.connect(lambda gen, patch: patches.append((gen, patch)))
+        worker.needs_full_reload.connect(fallbacks.append)
+
+        _run_thread_to_completion(worker)
+
+        assert patches == []
+        assert fallbacks == [3]  # generation preserved on fallback too
+
+
+# ─────────────────────────────────────────────────────────────────────
+# F3: MainWindow._on_room_patch drops stale-generation signals
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestQuickRefreshGenerationGuard:
+    """_on_room_patch must ignore signals from superseded workers.
+
+    Reproduces "Vector 2" from the fix plan: a fileChanged burst
+    spawns worker A, then worker B before A has finished; both
+    eventually emit room_patch.  Only B's patch should be applied.
+    """
+
+    def _bare_window(self):
+        """Construct a MainWindow stand-in with just the attributes
+        `_on_room_patch` touches.  We can't spin up a real MainWindow
+        here (it touches GPAKs, locales, config files, …) so we mock
+        out everything that isn't on the race-critical path.
+        """
+        window = main_window_module.MainWindow.__new__(main_window_module.MainWindow)
+        window._quick_refresh_generation = 5
+        window._quick_refresh_worker = object()  # sentinel
+        window._cats = [SimpleNamespace(db_key=1, room="Attic", status="In House")]
+        # Everything below is only touched in the non-stale branch; we
+        # want the stale branch to return before reaching them so these
+        # can all be bare stubs / None.
+        window._source_model = SimpleNamespace(layoutChanged=SimpleNamespace(emit=lambda: None))
+        window._proxy_model = SimpleNamespace(invalidate=lambda: None)
+        window._rebuild_room_buttons = lambda cats: None
+        window._refresh_filter_button_counts = lambda: None
+        window._bump_cats_generation = lambda: None
+        window._furniture_view = None
+        window._tree_view = None
+        window._safe_breeding_view = None
+        window._breeding_partners_view = None
+        window._room_optimizer_view = None
+        window._perfect_planner_view = None
+        window._calibration_view = None
+        window._cats_generation = 0
+        window._view_generation = {}
+        window._furniture = []
+        window._furniture_data = None
+        window._available_house_rooms = []
+        window._current_save = ""
+        window.statusBar = lambda: SimpleNamespace(showMessage=lambda *a, **k: None)
+        return window
+
+    def test_stale_generation_is_dropped(self, qt_app):
+        window = self._bare_window()
+        pre_cats = window._cats
+        pre_worker = window._quick_refresh_worker
+
+        # Signal from a worker with an older generation — must be dropped
+        # without touching state.
+        main_window_module.MainWindow._on_room_patch(
+            window, 4, {1: ("Floor1_Large", "In House")}
+        )
+
+        assert window._cats is pre_cats
+        assert window._cats[0].room == "Attic"  # unchanged
+        assert window._quick_refresh_worker is pre_worker  # not reset
+
+    def test_current_generation_is_applied(self, qt_app):
+        window = self._bare_window()
+
+        main_window_module.MainWindow._on_room_patch(
+            window, 5, {1: ("Floor1_Large", "In House")}
+        )
+
+        assert window._cats[0].room == "Floor1_Large"
+        assert window._quick_refresh_worker is None
+
+    def test_exception_in_body_falls_back_without_crashing(self, qt_app):
+        """If something inside the body raises (e.g. a deleted Qt
+        object), the slot must swallow the exception and schedule a
+        reload rather than aborting the event loop.
+        """
+        window = self._bare_window()
+
+        # Blow up partway through by making invalidate() throw.
+        def boom():
+            raise RuntimeError("Internal C++ object already deleted")
+        window._proxy_model.invalidate = boom
+
+        reloads = []
+        window._reload = lambda: reloads.append(True)
+        # Monkeypatch QTimer.singleShot for the fallback so we can assert
+        # it was scheduled without actually deferring.
+        with patch.object(main_window_module, "QTimer") as qtimer_mock:
+            qtimer_mock.singleShot = lambda ms, fn: fn()
+            # The try/except body does not crash the process:
+            main_window_module.MainWindow._on_room_patch(
+                window, 5, {1: ("Floor1_Large", "In House")}
+            )
+
+        assert reloads == [True]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# F4: _on_save_loaded drops results from superseded workers
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestSaveLoadSupersededGuard:
+    def test_stale_save_load_result_is_discarded(self, qt_app):
+        """A superseded SaveLoadWorker (one replaced by a newer
+        load_save call) must have its finished_load result dropped
+        instead of overwriting fresh state.
+        """
+        window = main_window_module.MainWindow.__new__(main_window_module.MainWindow)
+
+        # Simulate state after load_save started a new worker B.
+        current_worker = SimpleNamespace(name="B")
+        window._save_load_worker = current_worker
+        # Tripwires: these must NOT be touched if the stale-worker guard
+        # fires correctly.
+        window._loading_overlay = SimpleNamespace(
+            hide=lambda: pytest.fail("stale result must not hide the overlay")
+        )
+        window._save_view_disabled = False
+
+        stale_worker = SimpleNamespace(name="A")
+        # Deliberately a malformed result — if we got past the guard
+        # the test would crash loudly, which is exactly what we want.
+        bogus_result = {}
+
+        main_window_module.MainWindow._on_save_loaded(
+            window, bogus_result, False, source_worker=stale_worker
+        )
+
+        # Current worker reference must still point at B.
+        assert window._save_load_worker is current_worker
+
+
+# ─────────────────────────────────────────────────────────────────────
+# F5: file watcher debounces bursts into a single refresh
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestFileWatcherDebounce:
+    def test_burst_events_collapse_to_one_refresh(self, qt_app):
+        """Five fileChanged events in quick succession must produce
+        exactly one _start_quick_room_refresh call after the debounce
+        window closes.
+        """
+        window = main_window_module.MainWindow.__new__(main_window_module.MainWindow)
+
+        # Minimum attrs needed by _on_file_changed_raw and
+        # _on_file_changed_debounced.
+        window._current_save = "/fake/save.sav"
+        window._watcher = SimpleNamespace(
+            files=lambda: ["/fake/save.sav"],  # already watched
+            addPath=lambda p: None,
+            removePaths=lambda ps: None,
+        )
+        window._pending_changed_path = None
+        window._cats = [SimpleNamespace(db_key=1)]
+        window._save_load_worker = None
+
+        refreshes = []
+        window._start_quick_room_refresh = lambda: refreshes.append(True)
+        window._reload = lambda: refreshes.append("reload")
+
+        window._file_change_timer = QTimer()
+        window._file_change_timer.setSingleShot(True)
+        window._file_change_timer.setInterval(50)  # shorter for test
+        window._file_change_timer.timeout.connect(
+            lambda: main_window_module.MainWindow._on_file_changed_debounced(window)
+        )
+
+        # Five rapid events — each restarts the timer.
+        for _ in range(5):
+            main_window_module.MainWindow._on_file_changed_raw(window, "/fake/save.sav")
+            time.sleep(0.005)
+
+        # Pump until the timer fires.
+        deadline = time.time() + 1.0
+        while not refreshes and time.time() < deadline:
+            qt_app.processEvents()
+            time.sleep(0.01)
+
+        assert refreshes == [True], (
+            f"expected exactly one quick refresh, got {refreshes!r}"
+        )


### PR DESCRIPTION
## Summary

This PR fixes a ~10% crash rate that occurred when the game rewrote its save file while the manager was open. The fixes address four race conditions and exception-handling gaps in the file-watching and worker lifecycle management.

## Key Changes

**F1/F6: Robust error handling in worker threads**
- `SaveLoadWorker` now wraps parsing in a try/except block and emits a `failed` signal instead of dying silently when parse errors occur
- Added `retry_transient()` utility that retries transient I/O errors (sqlite3 locks, truncated files, etc.) with exponential backoff while immediately propagating real bugs (TypeError, corrupt data, etc.)
- Both `SaveLoadWorker` and `QuickRoomRefreshWorker` use `retry_transient()` to recover from the partial-write window when the game atomically renames its temp save file
- New `_on_save_load_failed()` slot surfaces parse errors in the status bar and schedules a self-healing retry 500ms later

**F3: Generation tokens prevent stale signals from clobbering state**
- `QuickRoomRefreshWorker` now accepts and re-emits a `generation` token with each `room_patch` signal
- `MainWindow._on_room_patch()` compares the generation token against `_quick_refresh_generation` and drops stale signals from superseded workers
- Similar generation-based guards added to `_on_phase1_ready()`, `_on_cache_ready()`, and `_on_save_loaded()` to prevent stale results from overwriting fresh state

**F4: Eliminate QThread.terminate() calls**
- Removed all `worker.quit()/wait()/terminate()` calls from `load_save()` and `_start_breeding_cache()`
- Instead, supersede workers by clearing the reference and letting them finish naturally
- Stale workers' result signals are discarded by identity check (`source_worker is not self._save_load_worker`)
- This prevents undefined behavior from terminating threads mid-parse while holding SQLite handles or the GIL

**F5: Debounce file-watcher bursts**
- Added `_file_change_timer` (250ms debounce window) to coalesce rapid `fileChanged` events into a single refresh
- `_on_file_changed_raw()` queues the path and restarts the timer on each event
- `_on_file_changed_debounced()` fires after the burst window closes, preventing multiple racing workers
- This was a major contributor to the crash rate, as the game often writes the save in rapid succession

## Implementation Details

- New `src/mewgenics/utils/retry.py` module provides `retry_transient()` with configurable delays (default: 50ms, 100ms, 200ms between attempts)
- Worker signals now include source worker identity or generation tokens as parameters
- Comprehensive regression test suite (`tests/test_game_update_crash_fixes.py`) verifies each fix in isolation without needing a real save file
- All changes maintain backward compatibility and don't alter the public API

https://claude.ai/code/session_014DN2wXKsaGPfp3ePtjg2M9