### PR TITLE
fix: address issues #93 (false-positive eyebrow defect) and #94 (game crash when both open)

### DIFF
--- a/src/mewgenics/utils/save_snapshot.py
+++ b/src/mewgenics/utils/save_snapshot.py
@@ -1,0 +1,64 @@
+"""Snapshot the live .sav to a temp file before reading.
+
+The Mewgenics game rewrites the save while it runs; our readers used to
+open the live file directly which contributed to shared-access crashes
+of the game on Windows (issue #94). Copying the file first removes all
+co-access between the game and this app.
+"""
+import logging
+import os
+import shutil
+import tempfile
+import time
+from contextlib import contextmanager
+
+logger = logging.getLogger("mewgenics.snapshot")
+
+# WAL / SHM / journal sidecars SQLite may produce. Present mostly for
+# Mewgenics' main save; harmless when absent.
+_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+
+
+def copy_save(path: str, tmp_dir: str) -> tuple[str, int]:
+    """Copy `path` (and any SQLite sidecars) into `tmp_dir`.
+
+    Returns (destination_path, bytes_copied).
+    """
+    base = os.path.basename(path)
+    dst = os.path.join(tmp_dir, base)
+    shutil.copy2(path, dst)
+    bytes_copied = os.path.getsize(dst)
+    for suffix in _SIDECAR_SUFFIXES:
+        src_side = path + suffix
+        if os.path.exists(src_side):
+            try:
+                shutil.copy2(src_side, dst + suffix)
+                bytes_copied += os.path.getsize(dst + suffix)
+            except OSError as exc:
+                logger.warning("could not copy sidecar %s: %s", src_side, exc)
+    return dst, bytes_copied
+
+
+@contextmanager
+def snapshot(path: str):
+    """Context manager yielding a snapshot path; removes the temp dir on exit.
+
+    Logs size + duration at INFO so uploaded user logs contain a concrete
+    trace of every save read — essential for diagnosing issue #94-style
+    reports where the root cause isn't reproducible locally.
+    """
+    tmp_dir = tempfile.mkdtemp(prefix="mew_save_")
+    try:
+        t0 = time.monotonic()
+        dst, bytes_copied = copy_save(path, tmp_dir)
+        copy_s = time.monotonic() - t0
+        logger.info(
+            "save snapshot path=%s bytes=%d copy_s=%.3f",
+            path, bytes_copied, copy_s,
+        )
+        yield dst
+    finally:
+        try:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+            logger.warning("snapshot cleanup failed for %s: %s", tmp_dir, exc)

--- a/src/mewgenics/workers/room_refresh.py
+++ b/src/mewgenics/workers/room_refresh.py
@@ -1,10 +1,15 @@
 """QuickRoomRefreshWorker: fast room assignment refresh without full parse."""
+import logging
 import sqlite3
 
 from PySide6.QtCore import QThread, Signal
 
 from save_parser import _get_house_info, _get_adventure_keys
 from mewgenics.utils.retry import retry_transient
+from mewgenics.utils.save_snapshot import snapshot
+
+
+logger = logging.getLogger("mewgenics.room_refresh")
 
 
 class QuickRoomRefreshWorker(QThread):
@@ -28,15 +33,15 @@ class QuickRoomRefreshWorker(QThread):
         self._expected_keys = expected_keys
         self._generation = generation
 
-    def _read_state(self):
-        """Open the save read-only and return (live_keys, house, adv).
+    def _read_state_from(self, src_path: str):
+        """Open `src_path` read-only and return (live_keys, house, adv).
 
         Raises the underlying sqlite3 exception if the file can't be opened
         or queried — retry_transient handles the partial-write window.
         """
         conn = None
         try:
-            conn = sqlite3.connect(f"file:{self._path}?mode=ro", uri=True)
+            conn = sqlite3.connect(f"file:{src_path}?mode=ro", uri=True)
             live_keys = {row[0] for row in conn.execute("SELECT key FROM cats").fetchall()}
             house = _get_house_info(conn)
             adv = _get_adventure_keys(conn)
@@ -55,7 +60,12 @@ class QuickRoomRefreshWorker(QThread):
         try:
             if self.isInterruptionRequested():
                 return
-            live_keys, house, adv = retry_transient(self._read_state)
+            # Snapshot the save to a temp copy first to avoid co-accessing
+            # the live file while the game is running (issue #94).
+            with snapshot(self._path) as snap_path:
+                live_keys, house, adv = retry_transient(
+                    lambda: self._read_state_from(snap_path)
+                )
             if self.isInterruptionRequested():
                 return
             if live_keys != self._expected_keys:
@@ -73,4 +83,5 @@ class QuickRoomRefreshWorker(QThread):
                 return
             self.room_patch.emit(self._generation, patch)
         except Exception:
+            logger.exception("quick room refresh failed; falling back to full reload")
             self.needs_full_reload.emit(self._generation)

--- a/src/mewgenics/workers/save_loader.py
+++ b/src/mewgenics/workers/save_loader.py
@@ -1,4 +1,8 @@
 """SaveLoadWorker: parses a save file off the main thread."""
+import logging
+import os
+import time
+
 from PySide6.QtCore import QThread, Signal
 
 from save_parser import parse_save
@@ -8,6 +12,10 @@ from mewgenics.utils.cat_persistence import (
 )
 from mewgenics.utils.calibration import _load_gender_overrides, _apply_calibration
 from mewgenics.utils.retry import retry_transient, TRANSIENT_EXCEPTIONS
+from mewgenics.utils.save_snapshot import snapshot
+
+
+logger = logging.getLogger("mewgenics.save_loader")
 
 
 class SaveLoadWorker(QThread):
@@ -26,39 +34,67 @@ class SaveLoadWorker(QThread):
         try:
             if self.isInterruptionRequested():
                 return
-            self.status.emit("Parsing save file…")
-            save = retry_transient(lambda: parse_save(self._path))
-            if self.isInterruptionRequested():
-                return
-            cats, errors, unlocked_house_rooms = save
-            self.status.emit("Loading blacklist & overrides…")
-            _load_blacklist(self._path, cats)
-            _load_must_breed(self._path, cats)
-            _load_pinned(self._path, cats)
-            _load_tags(self._path, cats)
-            _load_not_adventured(self._path, cats)
-            applied_overrides, override_rows = _load_gender_overrides(self._path, cats)
-            cal_explicit, cal_token, cal_rows = _apply_calibration(self._path, cats)
-            if self.isInterruptionRequested():
-                return
-            self.finished_load.emit({
-                "cats": cats,
-                "errors": errors,
-                "unlocked_house_rooms": unlocked_house_rooms,
-                "accessible_cats": save.accessible_cats,
-                "furniture": save.furniture,
-                "furniture_by_room": save.furniture_by_room,
-                "pedigree_coi_memos": save.pedigree_coi_memos,
-                "applied_overrides": applied_overrides,
-                "override_rows": override_rows,
-                "cal_explicit": cal_explicit,
-                "cal_token": cal_token,
-                "cal_rows": cal_rows,
-            })
+            try:
+                live_size = os.path.getsize(self._path)
+                live_mtime = os.path.getmtime(self._path)
+            except OSError as exc:
+                logger.warning("stat failed on %s: %s", self._path, exc)
+                live_size = -1
+                live_mtime = 0.0
+            logger.info(
+                "save load start path=%s size=%d mtime=%.3f",
+                self._path, live_size, live_mtime,
+            )
+            self.status.emit("Snapshotting save file…")
+            # Snapshot to temp so we never hold a handle to the live save
+            # while the game is running (issue #94). retry_transient
+            # handles the atomic-rename window when the game writes
+            # mid-copy.
+            with snapshot(self._path) as snapshot_path:
+                if self.isInterruptionRequested():
+                    return
+                self.status.emit("Parsing save file…")
+                t_parse = time.monotonic()
+                save = retry_transient(lambda: parse_save(snapshot_path))
+                parse_s = time.monotonic() - t_parse
+                logger.info("save parse ok parse_s=%.3f", parse_s)
+                if self.isInterruptionRequested():
+                    return
+                cats, errors, unlocked_house_rooms = save
+                logger.info(
+                    "save load summary cats=%d errors=%d",
+                    len(cats), len(errors),
+                )
+                self.status.emit("Loading blacklist & overrides…")
+                # Sidecar loads key off the *live* save path, not the snapshot.
+                _load_blacklist(self._path, cats)
+                _load_must_breed(self._path, cats)
+                _load_pinned(self._path, cats)
+                _load_tags(self._path, cats)
+                _load_not_adventured(self._path, cats)
+                applied_overrides, override_rows = _load_gender_overrides(self._path, cats)
+                cal_explicit, cal_token, cal_rows = _apply_calibration(self._path, cats)
+                if self.isInterruptionRequested():
+                    return
+                self.finished_load.emit({
+                    "cats": cats,
+                    "errors": errors,
+                    "unlocked_house_rooms": unlocked_house_rooms,
+                    "accessible_cats": save.accessible_cats,
+                    "furniture": save.furniture,
+                    "furniture_by_room": save.furniture_by_room,
+                    "pedigree_coi_memos": save.pedigree_coi_memos,
+                    "applied_overrides": applied_overrides,
+                    "override_rows": override_rows,
+                    "cal_explicit": cal_explicit,
+                    "cal_token": cal_token,
+                    "cal_rows": cal_rows,
+                })
         except Exception as exc:  # noqa: BLE001 — last line of defence before QThread dies silently
             # Without this, an unhandled exception would kill the QThread,
             # `finished_load` would never fire, the loading overlay would
             # stay up, and `_save_load_worker` on MainWindow would remain
             # non-None — so every subsequent file-change event would
             # cascade into the old terminate() path.
+            logger.exception("save load failed for %s", self._path)
             self.failed.emit(repr(exc), isinstance(exc, TRANSIENT_EXCEPTIONS))

--- a/src/save_parser.py
+++ b/src/save_parser.py
@@ -1048,11 +1048,18 @@ def _read_visual_mutation_entries(table: list[int]) -> list[dict[str, object]]:
             continue
 
         part_label = _VISUAL_MUTATION_PART_LABELS.get(group_key, slot_label)
-        is_defect = (700 <= mutation_id <= 706) or mutation_id == 0xFFFF_FFFE
+        # Sentinel "missing part" is always a defect. Range heuristic
+        # (700–706) is only used as a fallback when the GPAK data for
+        # this mutation does not carry an explicit `tag birth_defect`
+        # marker — GPAK is authoritative otherwise. See issue #93: some
+        # 700-range mutations are normal variants, not defects.
+        is_sentinel_missing = (mutation_id == 0xFFFF_FFFE)
+        is_defect = is_sentinel_missing
         display_name = ""
         detail = ""
         gon_stats = ""
         source = "generic"
+        defect_source = "sentinel" if is_sentinel_missing else "none"
         catalog_name = fallback_names.get((fallback_part, mutation_id))
         gpak_info = _VISUAL_MUT_DATA.get(gpak_category, {}).get(mutation_id)
         # Skip base/default part IDs — real mutations have gpak_info or a
@@ -1068,8 +1075,19 @@ def _read_visual_mutation_entries(table: list[int]) -> list[dict[str, object]]:
             raw_name = _gi[0] if len(_gi) >= 1 else ""
             stat_desc = _gi[1] if len(_gi) >= 2 else ""
             gon_stats = _gi[2] if len(_gi) >= 3 else ""
-            if len(_gi) >= 4 and bool(_gi[3]):
+            if len(_gi) >= 4:
+                # GPAK is authoritative: trust its birth_defect tag.
+                if bool(_gi[3]):
+                    is_defect = True
+                    defect_source = "gpak"
+            elif not is_sentinel_missing and 700 <= mutation_id <= 706:
+                # Legacy 3-tuple GPAK entry — fall back to the range heuristic.
                 is_defect = True
+                defect_source = "range_fallback_gpak3tuple"
+        elif not is_sentinel_missing and 700 <= mutation_id <= 706:
+            # No GPAK data at all — use the range heuristic as a best guess.
+            is_defect = True
+            defect_source = "range_fallback_no_gpak"
             raw_name = str(raw_name).strip()
             detail = str(stat_desc).strip()
             if raw_name and not re.match(r'^Mutation \d+$', raw_name):
@@ -1098,14 +1116,24 @@ def _read_visual_mutation_entries(table: list[int]) -> list[dict[str, object]]:
         display_name = str(display_name).strip() or f"{slot_label} {mutation_id}"
         if logger.isEnabledFor(logging.DEBUG) and (verbose_logs or not _is_synthetic_visual_mutation_name(display_name, part_label, slot_label, mutation_id)):
             logger.debug(
-                "visual mutation slot=%s table_index=%s mutation_id=%s gpak_category=%s source=%s name=%s detail=%s",
+                "visual mutation slot=%s table_index=%s mutation_id=%s gpak_category=%s source=%s defect=%s defect_source=%s name=%s detail=%s",
                 slot_key,
                 table_index,
                 mutation_id,
                 gpak_category,
                 source,
+                is_defect,
+                defect_source,
                 display_name,
                 detail,
+            )
+        if is_defect:
+            # Always log defect detections at INFO so uploaded user logs
+            # show exactly which mutation was flagged and why. Cheap —
+            # most cats have 0–2 defects.
+            logger.info(
+                "defect detected slot=%s mutation_id=%s gpak_category=%s defect_source=%s name=%s",
+                slot_key, mutation_id, gpak_category, defect_source, display_name,
             )
         entries.append({
             "slot_key": slot_key,


### PR DESCRIPTION
## Summary
- **#93** — eyebrow-701 ("no eyebrows") was always flagged as a birth defect because a hardcoded 700–706 range check ran *before* GPAK data had a chance to weigh in. GPAK's `tag birth_defect` marker is now authoritative when present; the range heuristic is only a fallback for legacy/missing entries. Every detected defect is also logged at INFO with its slot/ID/source so users uploading logs let us pinpoint mis-detections.
- **#94** — the game crashes on Windows when both it and the manager are open. Both save readers (`SaveLoadWorker` full parse and `QuickRoomRefreshWorker` fast path) now copy the `.sav` (plus any `-wal`/`-shm`/`-journal` sidecars) to a temp directory first and read the copy, so there's no co-access with the running game. Added a shared `save_snapshot` helper and INFO-level timing/size logs around snapshot and parse so uploaded logs contain a complete trace of every read.

If #94 keeps reproducing after this, the logs will capture:
- `save load start path=… size=… mtime=…`
- `save snapshot path=… bytes=… copy_s=…`
- `save parse ok parse_s=…`
- `save load summary cats=… errors=…`
- Every `defect detected slot=… mutation_id=… defect_source=… name=…` line

Closes #93. Addresses #94 (keep open pending user confirmation).

## Test plan
- [ ] Launch the game and the manager simultaneously; exercise breed/save loop and confirm no game crashes.
- [ ] Load a save that previously showed the phantom eyebrow defect and verify the chip no longer appears on cats without a GPAK-tagged defect.
- [ ] Inspect `%APPDATA%/MewgenicsBreedingManager/logs/mewgenics.log` after a load and confirm the new snapshot/parse/defect lines are present.
- [ ] `pytest tests/test_game_update_crash_fixes.py` still passes (monkey-patched sqlite / parse_save shims still exercise the post-snapshot path).