### PR TITLE
Address issues #102-#104 + P7P breeding compat floor

### DIFF
--- a/docs/superpowers/specs/2026-04-23-getting-started-help-design.md
+++ b/docs/superpowers/specs/2026-04-23-getting-started-help-design.md
@@ -1,0 +1,383 @@
+# Getting Started Help And First-Run Prompt — Design Spec
+
+## Overview
+
+Expand the existing `Getting Started` dialog into a practical, reusable guide for intermediate Mewgenics players who understand breeding in the game but do not yet understand how to use this app well.
+
+The guide should serve two jobs:
+
+1. Be available at any time from `Help > Getting Started`
+2. Be discoverable on startup through a lightweight first-run prompt
+
+This is not a live UI spotlight tutorial. It is a multi-page walkthrough that explains what each major function is for, when to use it, and what kind of answer it gives the player.
+
+The guide should reflect the app's real value proposition:
+
+- it puts all your cat information in one place
+- it helps you inspect and organize your population
+- it helps you identify weak cats to cull or donate
+- it helps you understand pair recommendations and longer-term breeding plans
+
+The copy should be practical and plainspoken rather than polished marketing language.
+
+## Goals
+
+- Give new-to-the-tool users a clear starting point without overwhelming them
+- Explain the main workflow of the app from roster inspection through planning
+- Explain major views in terms of player decisions, not just UI controls
+- Keep `Getting Started` useful as a permanent help reference
+- Add a startup prompt that asks whether to open the guide, skip once, or always skip
+- Preserve the existing `What's New` flow for release notes
+
+## Non-Goals
+
+- No live guided tour that highlights widgets or forces navigation through the main window
+- No rewrite of `About` or `What's New` into documentation hubs
+- No large-scale documentation system outside the existing dialog flow
+- No dependency on external network content inside the app beyond clickable links
+
+## Existing Context
+
+The app already has:
+
+- `Help > Getting Started`
+- `Help > What's New`
+- `Help > About`
+- an existing `OnboardingDialog` implemented as a `QStackedWidget` with `Back`, `Next`, and `Finish`
+- startup logic that decides whether to show onboarding or `What's New` based on `last_seen_version`
+
+That existing structure should be reused rather than replaced.
+
+## User Experience Summary
+
+### First-Run / Startup Experience
+
+When a user launches the app and onboarding prompting is still enabled, the app should show a small modal prompt before the full guide.
+
+The prompt should not try to teach the app. Its only job is to route the user into the expanded guide or let them dismiss it.
+
+Suggested prompt content:
+
+- Title: `New to Mewgenics Breeding Manager?`
+- Body: short copy explaining that the app has grown a lot and the guide walks through the main workflow and major tools
+- Buttons:
+  - `Open Getting Started`
+  - `Skip This Time`
+  - `Always Skip`
+
+Behavior:
+
+- `Open Getting Started` opens the full guide
+- `Skip This Time` closes the prompt and asks again on a later launch
+- `Always Skip` stores a persistent preference and suppresses future auto-prompts
+- `Help > Getting Started` always remains available regardless of the saved preference
+
+### Help Menu Experience
+
+`Help > Getting Started` should always open the full guide directly.
+
+This should not show the startup prompt first. The prompt is only for automatic startup behavior.
+
+### Guide Experience
+
+The guide remains a modal multi-page dialog with:
+
+- one page title
+- one body area using `QTextBrowser`
+- `Back`, `Next`, and `Finish` buttons
+- a `Page X of Y` label
+
+The dialog remains reusable from Help and from startup.
+
+## Information Architecture
+
+The expanded guide should use nine pages.
+
+### 1. Start Here
+
+Purpose:
+Explain what the app is for in plain language.
+
+Required content:
+
+- The app puts all the information about your cats in one place so you can make better decisions
+- The main use case is understanding your population before deciding what to breed, keep, or cull
+- The common long-term goal is preserving strong stats and strong mutations while removing low-value cats and weak lines
+- A beginner-friendly LLM suggestion appears near the top:
+  - export cats with `File > Export Cats`
+  - give an LLM the exported CSV plus the [Breeding wiki page](https://mewgenics.wiki.gg/wiki/Breeding)
+  - ask what to do next
+
+Tone:
+Very clear and grounded. This page should reduce “where do I even start?” anxiety.
+
+### 2. Your Main Workflow
+
+Purpose:
+Explain the normal loop for using the app.
+
+Required content:
+
+- Load your save
+- Inspect the roster
+- Identify weak cats and obvious cuts
+- Compare promising pair options
+- Use planning tools when you want a longer-term strategy
+- Export and ask for help if you need another layer of interpretation
+
+Key message:
+The app works best as a funnel. Start broad with the full roster, then narrow into scoring, pair analysis, and planning.
+
+### 3. Roster: Your Home Base
+
+Purpose:
+Explain how to use the roster as the default starting point.
+
+Required content:
+
+- Sort and filter to understand your full population
+- Click cats to inspect details
+- Use the roster to compare stats, mutations, disorders, lineage, and other context
+- Use tags and quick actions to stay organized
+
+Key message:
+If you are confused, start in the roster.
+
+### 4. Find Weak Cats Fast
+
+Purpose:
+Teach the fastest path to culling and triage.
+
+Required content:
+
+- `Donation Candidates` is for quick triage and finding the worst offenders
+- `Simple Scoring` is for ranking cats according to your own priorities
+- This is the best place to start if the real goal is to identify shitty cats, weak lines, or obvious cuts
+
+Page structure:
+
+- short intro paragraph
+- one subsection for `Donation Candidates`
+- one subsection for `Simple Scoring`
+- one short “use this when...” summary for each
+
+### 5. Understand Pair Suggestions
+
+Purpose:
+Explain what pair recommendation tools are doing and why their output can be non-obvious.
+
+Required content:
+
+- Pair views are not only matching the two most obviously strong cats
+- The app is searching across many possible combinations and surfacing promising pairs based on tradeoffs
+- A pair may be recommended because it supports a better long-term direction, preserves rare strengths, avoids a worse risk, or complements weaknesses well
+- If the app spits out several top pairs, that is a signal about strategy rather than a command
+
+This page should also include example LLM prompts such as:
+
+- `Why is the tool recommending these 4 pairs?`
+- `What is it trying to optimize for?`
+- `What tradeoffs is it making between these pair options?`
+
+### 6. Detailed Scoring
+
+Purpose:
+Explain when and why to use the more strategic scoring tools.
+
+Required content:
+
+- `Detailed Scoring` is a more strategic ranking tool than `Simple Scoring`
+- It helps when the roster is large enough that quick eyeballing stops working
+- Profiles and weights let the player ask different strategic questions
+- Users do not need to master this immediately
+
+Key message:
+This is the place to come when you want more nuance, not the first tool every user must learn.
+
+### 7. Planning Tools
+
+Purpose:
+Explain longer-horizon tools like room and planner views.
+
+Required content:
+
+- Planning views matter once the player already knows which cats are worth investing in
+- These tools help compare breeding directions, not just one-off cats
+- The value here is project-level planning rather than quick inspection
+
+This page should explain that the app can help the player think in generations, not just individual pair quality.
+
+### 8. Family Tree And Context
+
+Purpose:
+Explain why the app exposes family and context-heavy views.
+
+Required content:
+
+- Good breeding decisions are not just about one cat’s current score
+- Family history and lineage matter
+- Use these views to understand how traits and risks move through a line
+
+Key message:
+The app keeps context because breeding decisions are better when you can see the line behind the cat.
+
+### 9. Export And Ask For Help
+
+Purpose:
+Close the guide with a practical “what next?” page.
+
+Required content:
+
+- Remind the user about `File > Export Cats`
+- Explain that exporting lets the player use outside help without retyping everything
+- Include example prompts:
+  - `Help me decide who to cull first`
+  - `Why are these pairs being recommended`
+  - `What should I do next with this roster`
+  - `Which lines are worth keeping and which should I stop investing in`
+
+This page should reinforce the wiki + CSV + LLM workflow from page 1.
+
+## Copywriting Guidelines
+
+- Write for intermediate players who know Mewgenics breeding concepts but do not know this tool
+- Keep the tone practical, direct, and plainspoken
+- Avoid sounding like release notes or marketing copy
+- Prefer “what this feature is for” over “here is every control on this screen”
+- Use blunt phrasing like “find weak cats fast” or “worst offenders” where it improves clarity
+
+## UI Design Details
+
+### Keep The Existing Dialog Pattern
+
+Reuse the existing `OnboardingDialog` pattern:
+
+- `QDialog`
+- `QStackedWidget`
+- one page per concept
+- `Back`, `Next`, `Finish`
+- `Page X of Y`
+
+This avoids introducing a second documentation surface.
+
+### Suggested Dialog Changes
+
+- Keep the window title as `Getting Started`
+- Change the top heading from `Welcome to Mewgenics Breeding Manager` to something more reusable, such as `Getting Started With Mewgenics Breeding Manager`
+- Keep the existing dark styling unless a separate UI cleanup is needed later
+- Allow links in page bodies
+
+### Readability Constraints
+
+Each page should be:
+
+- one short intro paragraph
+- 3 to 6 bullets or short subsections
+- optionally one short “try this” or “use this when...” block
+
+Pages can scroll, but the design target should be “readable in one sitting,” not mini-manuals.
+
+## Startup Prompt Design
+
+### New Dialog
+
+Add a lightweight startup prompt dialog separate from the full guide.
+
+Responsibilities:
+
+- ask whether the user wants help getting started
+- optionally suppress future startup prompting
+- launch the full guide when requested
+
+This prompt should not replace the full guide. It only decides whether to open it automatically.
+
+### Persisted Preference
+
+Store a dedicated onboarding-prompt preference in app config.
+
+Required shape:
+
+- `show_getting_started_prompt: true/false`
+
+This key must be separate from version tracking and should default to `true` when missing.
+
+### Separation From Release Notes
+
+Do not overload `last_seen_version` for onboarding prompting.
+
+Required behavior:
+
+- `What's New` remains version-driven
+- onboarding prompt remains preference-driven
+
+This avoids conflicts such as:
+
+- a returning user who has skipped onboarding forever but should still see a new release note
+- a first-time user who should see onboarding help without teaching the app through the release-notes dialog
+
+## MainWindow Behavior
+
+Startup flow should become:
+
+1. Check whether startup dialogs have already been shown
+2. If the user has not seen the current version’s release notes, preserve the existing `What's New` behavior
+3. Independently decide whether to show the onboarding/startup prompt
+4. If the user chooses `Open Getting Started`, open the full guide
+
+Ordering requirement:
+
+- First-time users should see the onboarding prompt rather than silently dropping into the main window
+- Returning users with a new version should still get `What's New`
+- If both are eligible, the onboarding prompt should not permanently suppress `What's New`, and vice versa
+
+Recommended handling:
+
+- show `What's New` when needed
+- then show onboarding prompt if onboarding prompting is enabled and the user still qualifies for it
+
+This keeps release messaging and evergreen help separate.
+
+## Implementation Boundaries
+
+Touched areas:
+
+- `src/mewgenics/dialogs.py`
+  - expand the existing `OnboardingDialog`
+  - add the lightweight startup prompt dialog
+- `src/mewgenics/main_window.py`
+  - update startup flow
+  - keep `Help > Getting Started` opening the full guide directly
+- `src/mewgenics/utils/config.py`
+  - add persistent config helpers for onboarding prompt preference
+
+No other architectural changes are required for this feature.
+
+## Edge Cases
+
+- Users who clicked `Always Skip` must still be able to open the guide from `Help`
+- Users upgrading versions should still get `What's New`
+- Users with missing or corrupted config should default to seeing the startup prompt
+- If the guide is opened from Help, it should never write skip preferences just because it was viewed
+
+## Testing Strategy
+
+Manual verification is sufficient for this feature.
+
+Required checks:
+
+- Fresh config shows the startup prompt
+- `Open Getting Started` opens the full guide
+- `Skip This Time` closes the prompt and shows it again next launch
+- `Always Skip` suppresses the prompt on later launches
+- `Help > Getting Started` still works after `Always Skip`
+- `What's New` still appears on version change
+- The new guide pages render correctly and links open externally
+- Page navigation works correctly from first page to last page
+
+## Open Decisions Resolved
+
+- Use the simpler multi-page guide, not a live step-by-step UI spotlight tutorial
+- Support both startup discovery and persistent Help access
+- Target intermediate players who know the game but not the tool
+- Keep the beginner-friendly LLM suggestion near the top of the guide
+- Add feature explanations oriented around player decisions rather than raw control descriptions

--- a/src/breed_priority/__init__.py
+++ b/src/breed_priority/__init__.py
@@ -214,6 +214,8 @@ class BreedPriorityView(QWidget):
         ability_tip: Callable(str) -> str; returns tooltip text for a trait.
     """
 
+    detailed_scores_updated = Signal()
+
     def __init__(self, ratings_path: str, stat_names: list, room_display: dict,
                  mutation_display_name, ability_tip):
         super().__init__()
@@ -2418,6 +2420,7 @@ class BreedPriorityView(QWidget):
                 ]
                 _stat_col_ranks[_sn] = ChipColors.stat_col_ranks(_col_vals) if _col_vals else {}
 
+        _detailed_scores_out: dict[int, float] = {}
         for row, cat in enumerate(alive):
             result = results[id(cat)]
             scope_gene_risk = result.scope_gene_risk
@@ -2804,6 +2807,7 @@ class BreedPriorityView(QWidget):
                 )
                 _cw_delta_total = sum(d for matched, d in _cw_matches if matched)
             _adjusted_total = result.total + _cw_delta_total
+            _detailed_scores_out[id(cat)] = float(_adjusted_total)
 
             # ── Total score ──
             score_item = _NumericSortItem(f"{_adjusted_total:+.1f}")
@@ -2882,6 +2886,15 @@ class BreedPriorityView(QWidget):
                     item.setToolTip(tooltip)
             self._score_table.setRowHeight(row, 36 if self._display_mode == "both" else 22)
 
+        try:
+            from mewgenics.utils.thresholds import _set_detailed_scores
+            _set_detailed_scores(_detailed_scores_out)
+        except Exception:
+            pass
+        try:
+            self.detailed_scores_updated.emit()
+        except Exception:
+            pass
         self._finalize_recompute(alive, results, _children_in_scope, _restore_name)
 
     def _finalize_recompute(self, alive, results, children_in_scope_fn, restore_name):

--- a/src/breeding.py
+++ b/src/breeding.py
@@ -80,13 +80,94 @@ def planner_pair_bias(a: Cat, b: Cat) -> float:
 
 
 def planner_pair_allows_breeding(a: Cat, b: Cat) -> bool:
-    """
-    Hard planner rule that follows the game's sexuality compatibility.
-
-    Same-sex pairs are allowed when their sexuality permits it, and straight
-    same-sex pairs remain blocked.
-    """
+    """Hard planner rule that follows the game's breeding compatibility."""
     return can_breed(a, b)[0]
+
+
+def _sexuality_coeff(cat: Cat) -> float:
+    """Return the cat's 0..1 sexuality coefficient (0=straight, 1=gay).
+
+    Prefer the raw float parsed from the save; fall back to the discretized
+    label if it's missing (older saves or override paths).
+    """
+    raw = getattr(cat, "sexuality_raw", None)
+    if isinstance(raw, (int, float)):
+        return max(0.0, min(1.0, float(raw)))
+    label = (getattr(cat, "sexuality", None) or "straight").lower()
+    if label == "gay":
+        return 1.0
+    if label == "bi":
+        return 0.5
+    return 0.05
+
+
+def estimate_breeding_compatibility(initiator: Cat, partner: Cat) -> float:
+    """Estimate the game's breeding compatibility score for a one-way pairing.
+
+    Implements the wiki formula:
+      compat = 0.15 * initiator_CHA * partner_libido * lover_mult * sexuality_mult
+
+    where sexuality_mult uses the partner's sexuality_coeff with
+    cos(0.5π·coeff) for opposite-sex pairs and sin(0.5π·coeff) for same-sex
+    pairs.  Unknown-gender pairs take sexuality_mult = 1.
+
+    Returns the raw compatibility (roll probability per the wiki, before the
+    sqrt(1+0.1·comfort) comfort multiplier).  Values below ~0.05 correspond
+    to pairs the game rejects outright.
+    """
+    if initiator is partner:
+        return 0.0
+    total_stats = getattr(initiator, "total_stats", None)
+    if total_stats is None:
+        # Likely a test stub or otherwise unpopulated Cat — we can't compute
+        # compatibility, so signal "unknown" by returning a high value rather
+        # than silently filtering the pair out.
+        return 1.0
+    cha = float(total_stats.get("CHA", 0) or 0)
+    libido_raw = getattr(partner, "libido", None)
+    libido = float(libido_raw) if libido_raw is not None else 1.0
+    if cha <= 0 or libido <= 0:
+        return 0.0
+
+    # Lover multiplier: partner-anchored with a default coeff of 0.25.
+    lover_coeff = 0.25
+    partner_lovers = getattr(partner, "lovers", []) or []
+    if partner_lovers:
+        if any(lv is initiator for lv in partner_lovers):
+            lover_mult = 1.0 + lover_coeff
+        else:
+            lover_mult = 1.0 - lover_coeff
+    else:
+        lover_mult = 1.0
+
+    ga = (initiator.gender or "?").strip().lower()
+    gb = (partner.gender or "?").strip().lower()
+    if ga == "?" or gb == "?":
+        sex_mult = 1.0
+    else:
+        coeff = _sexuality_coeff(partner)
+        if ga == gb:
+            sex_mult = math.sin(0.5 * math.pi * coeff)
+        else:
+            sex_mult = math.cos(0.5 * math.pi * coeff)
+
+    return 0.15 * cha * libido * lover_mult * sex_mult
+
+
+def pair_breeding_compatibility(a: Cat, b: Cat) -> float:
+    """Symmetric compatibility estimate for a pair.
+
+    Returns the *worst-direction* compat so the planner filter matches
+    "this pair reliably produces kittens regardless of who initiates".
+    The game picks a random initiator each day and same-sex pairs see
+    wildly asymmetric sex_mult values when the two cats have different
+    sexuality coefficients — using max would let those pairs slip past
+    a floor even though half of initiations would fail.
+    """
+    return min(
+        estimate_breeding_compatibility(a, b),
+        estimate_breeding_compatibility(b, a),
+    )
 
 
 def planner_inbreeding_penalty(a: Cat, b: Cat) -> float:

--- a/src/mewgenics/app.py
+++ b/src/mewgenics/app.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
     QApplication, QDialog, QMessageBox, QWidget,
     QVBoxLayout, QLabel, QProgressBar,
 )
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QPalette, QFont
 
 from mewgenics.utils.paths import APP_VERSION
@@ -165,18 +165,7 @@ def main():
 
         def _dismiss_splash():
             splash.close()
-
-        # The deferred QTimer.singleShot(0, load_save) in MainWindow.__init__
-        # starts a SaveLoadWorker.  Hook its completion to close the splash.
-        # We need a small delay so the worker is created first.
-        def _hook_worker():
-            worker = getattr(win, "_save_load_worker", None)
-            if worker is not None:
-                worker.finished_load.connect(_dismiss_splash)
-            else:
-                splash.close()
-
-        QTimer.singleShot(50, _hook_worker)
+        win.startup_save_load_finished.connect(_dismiss_splash)
     else:
         splash.close()
 

--- a/src/mewgenics/dialogs.py
+++ b/src/mewgenics/dialogs.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from PySide6.QtWidgets import (
     QWidget, QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton,
-    QScrollArea, QFrame, QGridLayout, QSpinBox, QDoubleSpinBox, QCheckBox,
+    QScrollArea, QFrame, QGridLayout, QSpinBox, QDoubleSpinBox, QCheckBox, QComboBox,
     QListWidget, QListWidgetItem, QFileDialog, QGroupBox,
     QStackedWidget, QTextBrowser, QDialogButtonBox,
     QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView,
@@ -1052,6 +1052,28 @@ class ThresholdPreferencesDialog(QDialog):
         grid.setHorizontalSpacing(10)
         grid.setVerticalSpacing(8)
 
+        self._score_source_combo = QComboBox()
+        self._score_source_combo.addItem(
+            _tr("thresholds.source.base_sum", default="Base stat sum"), "base_sum"
+        )
+        self._score_source_combo.addItem(
+            _tr("thresholds.source.detailed", default="Detailed Scoring total"), "detailed"
+        )
+        current_source = str(self._prefs.get("score_source", "base_sum"))
+        idx = self._score_source_combo.findData(current_source)
+        if idx >= 0:
+            self._score_source_combo.setCurrentIndex(idx)
+        self._score_source_combo.setToolTip(_tr(
+            "thresholds.source.tooltip",
+            default=(
+                "Base stat sum compares raw base-stat totals against the "
+                "integer thresholds below.  Detailed Scoring uses the latest "
+                "total produced by the Detailed Scoring view — open that view "
+                "at least once per save so the cache is populated."
+            ),
+        ))
+        self._score_source_combo.currentIndexChanged.connect(self._update_preview)
+
         self._exceptional_spin = QSpinBox()
         self._exceptional_spin.setRange(0, 999)
         self._exceptional_spin.setValue(self._prefs["exceptional_sum_threshold"])
@@ -1066,6 +1088,20 @@ class ThresholdPreferencesDialog(QDialog):
         self._top_stat_spin.setRange(0, 20)
         self._top_stat_spin.setValue(self._prefs["donation_max_top_stat"])
         self._top_stat_spin.valueChanged.connect(self._update_preview)
+
+        self._detailed_exceptional_spin = QDoubleSpinBox()
+        self._detailed_exceptional_spin.setRange(-999.0, 999.0)
+        self._detailed_exceptional_spin.setDecimals(1)
+        self._detailed_exceptional_spin.setSingleStep(1.0)
+        self._detailed_exceptional_spin.setValue(float(self._prefs.get("detailed_exceptional_threshold", 20.0)))
+        self._detailed_exceptional_spin.valueChanged.connect(self._update_preview)
+
+        self._detailed_donation_spin = QDoubleSpinBox()
+        self._detailed_donation_spin.setRange(-999.0, 999.0)
+        self._detailed_donation_spin.setDecimals(1)
+        self._detailed_donation_spin.setSingleStep(1.0)
+        self._detailed_donation_spin.setValue(float(self._prefs.get("detailed_donation_threshold", -5.0)))
+        self._detailed_donation_spin.valueChanged.connect(self._update_preview)
 
         self._planner_trait_check = QCheckBox(_tr(
             "thresholds.planner_trait_toggle",
@@ -1099,18 +1135,34 @@ class ThresholdPreferencesDialog(QDialog):
         self._curve_spin.setValue(float(self._prefs["adaptive_curve_strength"]))
         self._curve_spin.valueChanged.connect(self._update_preview)
 
-        grid.addWidget(QLabel(_tr("thresholds.exceptional", default="Exceptional threshold")), 0, 0)
-        grid.addWidget(self._exceptional_spin, 0, 1)
-        grid.addWidget(QLabel(_tr("thresholds.donation", default="Donation threshold")), 1, 0)
-        grid.addWidget(self._donation_spin, 1, 1)
-        grid.addWidget(QLabel(_tr("thresholds.donation_top_stat", default="Donation max top stat")), 2, 0)
-        grid.addWidget(self._top_stat_spin, 2, 1)
-        grid.addWidget(self._planner_trait_check, 3, 0, 1, 2)
-        grid.addWidget(self._adaptive_check, 4, 0, 1, 2)
-        grid.addWidget(QLabel(_tr("thresholds.reference_average", default="Reference living average")), 5, 0)
-        grid.addWidget(self._reference_spin, 5, 1)
-        grid.addWidget(QLabel(_tr("thresholds.curve_strength", default="Curve strength")), 6, 0)
-        grid.addWidget(self._curve_spin, 6, 1)
+        self._source_label = QLabel(_tr("thresholds.source", default="Score source"))
+        grid.addWidget(self._source_label, 0, 0)
+        grid.addWidget(self._score_source_combo, 0, 1)
+        self._base_exc_label = QLabel(_tr("thresholds.exceptional", default="Exceptional threshold"))
+        grid.addWidget(self._base_exc_label, 1, 0)
+        grid.addWidget(self._exceptional_spin, 1, 1)
+        self._base_don_label = QLabel(_tr("thresholds.donation", default="Donation threshold"))
+        grid.addWidget(self._base_don_label, 2, 0)
+        grid.addWidget(self._donation_spin, 2, 1)
+        self._base_top_label = QLabel(_tr("thresholds.donation_top_stat", default="Donation max top stat"))
+        grid.addWidget(self._base_top_label, 3, 0)
+        grid.addWidget(self._top_stat_spin, 3, 1)
+        self._detailed_exc_label = QLabel(_tr(
+            "thresholds.detailed_exceptional", default="Exceptional detailed score"
+        ))
+        grid.addWidget(self._detailed_exc_label, 4, 0)
+        grid.addWidget(self._detailed_exceptional_spin, 4, 1)
+        self._detailed_don_label = QLabel(_tr(
+            "thresholds.detailed_donation", default="Donation detailed score"
+        ))
+        grid.addWidget(self._detailed_don_label, 5, 0)
+        grid.addWidget(self._detailed_donation_spin, 5, 1)
+        grid.addWidget(self._planner_trait_check, 6, 0, 1, 2)
+        grid.addWidget(self._adaptive_check, 7, 0, 1, 2)
+        grid.addWidget(QLabel(_tr("thresholds.reference_average", default="Reference living average")), 8, 0)
+        grid.addWidget(self._reference_spin, 8, 1)
+        grid.addWidget(QLabel(_tr("thresholds.curve_strength", default="Curve strength")), 9, 0)
+        grid.addWidget(self._curve_spin, 9, 1)
         root.addLayout(grid)
 
         self._current_avg_label = QLabel()
@@ -1134,12 +1186,25 @@ class ThresholdPreferencesDialog(QDialog):
         root.addLayout(button_row)
 
         self._adaptive_check.toggled.connect(self._update_adaptive_controls)
+        self._score_source_combo.currentIndexChanged.connect(self._update_source_visibility)
         self._update_adaptive_controls(self._adaptive_check.isChecked())
+        self._update_source_visibility()
         self._update_preview()
 
     def _update_adaptive_controls(self, enabled: bool):
         self._reference_spin.setEnabled(enabled)
         self._curve_spin.setEnabled(enabled)
+
+    def _update_source_visibility(self, *_args):
+        source = str(self._score_source_combo.currentData() or "base_sum")
+        use_detailed = source == "detailed"
+        for widget in (self._base_exc_label, self._exceptional_spin,
+                       self._base_don_label, self._donation_spin,
+                       self._base_top_label, self._top_stat_spin):
+            widget.setVisible(not use_detailed)
+        for widget in (self._detailed_exc_label, self._detailed_exceptional_spin,
+                       self._detailed_don_label, self._detailed_donation_spin):
+            widget.setVisible(use_detailed)
 
     def _sync_exceptional_floor(self):
         if self._exceptional_spin.value() < self._donation_spin.value():
@@ -1158,12 +1223,42 @@ class ThresholdPreferencesDialog(QDialog):
             "adaptive_enabled": bool(self._adaptive_check.isChecked()),
             "adaptive_reference_avg_sum": float(self._reference_spin.value()),
             "adaptive_curve_strength": float(self._curve_spin.value()),
+            "score_source": str(self._score_source_combo.currentData() or "base_sum"),
+            "detailed_exceptional_threshold": float(self._detailed_exceptional_spin.value()),
+            "detailed_donation_threshold": float(self._detailed_donation_spin.value()),
         }
 
     def _update_preview(self, *_args):
         self._sync_exceptional_floor()
         prefs = _normalize_threshold_preferences(self._collect_preferences())
         exceptional, donation, top_stat, avg_sum = _effective_thresholds_for_cats(prefs, self._cats)
+        if prefs.get("score_source") == "detailed":
+            det_exc = prefs["detailed_exceptional_threshold"]
+            det_don = prefs["detailed_donation_threshold"]
+            preview_text = _tr(
+                "thresholds.preview_detailed",
+                default="Detailed Scoring: Exceptional >= {exc:+.1f}, Donation <= {don:+.1f}",
+                exc=det_exc,
+                don=det_don,
+            )
+            from mewgenics.utils.thresholds import _detailed_scores_ready
+            if not _detailed_scores_ready():
+                preview_text += _tr(
+                    "thresholds.preview_detailed.cache_missing",
+                    default=" — open the Detailed Scoring view to populate the cache; base-sum is used until then.",
+                )
+            self._preview_label.setText(preview_text)
+            if self._cats:
+                self._current_avg_label.setText(
+                    _tr(
+                        "thresholds.current_average",
+                        default="Living cats average base sum: {avg:.1f}",
+                        avg=avg_sum,
+                    )
+                )
+            else:
+                self._current_avg_label.setText("")
+            return
         if self._cats:
             self._current_avg_label.setText(
                 _tr(

--- a/src/mewgenics/main_window.py
+++ b/src/mewgenics/main_window.py
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import (
     Qt, QEvent, QModelIndex, QItemSelection, QItemSelectionModel,
-    QFileSystemWatcher, QThread, QTimer, QSize, QByteArray,
+    QFileSystemWatcher, QThread, QTimer, QSize, QByteArray, Signal,
 )
 from PySide6.QtGui import (
     QColor, QBrush, QAction, QActionGroup, QFont, QKeySequence,
@@ -141,6 +141,7 @@ class MainWindow(QMainWindow):
     # After this, we stop and wait for a fresh fileChanged event (or manual
     # reload) rather than spinning on a permanently-broken save.
     _SAVE_LOAD_RETRY_CAP = 3
+    startup_save_load_finished = Signal()
 
     @staticmethod
     def _set_bulk_toggle_label(btn: QPushButton, label: str, enabled: bool):
@@ -1188,7 +1189,19 @@ class MainWindow(QMainWindow):
                 planner_note = (
                     " Donation candidates are cats missing selected mutation/ability traits and still under the stat floor."
                 )
-        if adaptive:
+        from mewgenics.utils.thresholds import (
+            SCORE_SOURCE, DETAILED_EXCEPTIONAL_THRESHOLD, DETAILED_DONATION_THRESHOLD,
+            _detailed_scores_ready,
+        )
+        if SCORE_SOURCE == "detailed" and _detailed_scores_ready():
+            self._btn_exceptional.setToolTip(
+                f"Exceptional breeders: Detailed Scoring total >= {DETAILED_EXCEPTIONAL_THRESHOLD:+.1f}."
+            )
+            self._btn_donation.setToolTip(
+                "Donation candidates: Detailed Scoring total "
+                f"<= {DETAILED_DONATION_THRESHOLD:+.1f}, and/or high aggression." + planner_note
+            )
+        elif adaptive:
             self._btn_exceptional.setToolTip(
                 "Exceptional breeders follow the living-cat average curve: "
                 f"base {base_exceptional}, reference avg {summary['adaptive_reference_avg_sum']:.1f}, "
@@ -1231,6 +1244,14 @@ class MainWindow(QMainWindow):
         self._refresh_filter_button_counts()
         self._refresh_bulk_view_buttons(room_key)
         self._update_count()
+
+    def _on_detailed_scores_changed(self):
+        """Detailed Scoring finished a run — refresh donation/exceptional UI
+        when the user has the Detailed score source active."""
+        from mewgenics.utils.thresholds import SCORE_SOURCE
+        if SCORE_SOURCE != "detailed":
+            return
+        self._refresh_threshold_sensitive_ui()
 
     def _sync_room_config_views(self):
         if self._room_optimizer_view is None or self._perfect_planner_view is None:
@@ -2264,6 +2285,7 @@ class MainWindow(QMainWindow):
         )
         self._breed_priority_view.hide()
         self._content_vb.addWidget(self._breed_priority_view, 1)
+        self._breed_priority_view.detailed_scores_updated.connect(self._on_detailed_scores_changed)
         self._push_cats_to_view_if_loaded("breed_priority", self._breed_priority_view)
 
     def _build_all_views(self):
@@ -3601,6 +3623,7 @@ class MainWindow(QMainWindow):
             return  # superseded — a newer load is already running
         self._save_load_worker = None
         self._loading_overlay.hide()
+        self.startup_save_load_finished.emit()
         if is_transient and self._save_load_retries < self._SAVE_LOAD_RETRY_CAP:
             self._save_load_retries += 1
             self.statusBar().showMessage(
@@ -3721,6 +3744,7 @@ class MainWindow(QMainWindow):
         self._save_load_retries = 0  # success resets the self-heal counter
         # Dismiss overlay immediately — UI work below is fast (model.load is O(n), no ancestry)
         self._loading_overlay.hide()
+        self.startup_save_load_finished.emit()
         self._save_view_disabled = True
         try:
             cats = result["cats"]
@@ -3740,6 +3764,11 @@ class MainWindow(QMainWindow):
 
             self._cats = cats
             self._bump_cats_generation()
+            # Stale detailed-score cache is keyed by id(cat) from the previous
+            # save — clear it so we fall back to base-sum until Detailed Scoring
+            # reruns against the new objects.
+            from mewgenics.utils.thresholds import _set_detailed_scores
+            _set_detailed_scores({})
             self._furniture = furniture
             self._furniture_by_room = furniture_by_room
             self._furniture_data = dict(_FURNITURE_DATA)
@@ -4017,17 +4046,22 @@ class MainWindow(QMainWindow):
         base_stat_headers  = ["Base " + s for s in STAT_NAMES]
         actual_stat_headers = ["Actual " + s for s in STAT_NAMES]
         headers = (
-            ["Name", "Status", "Room", "Age", "Gender", "Sexuality", "Generation"]
+            ["Name", "Status", "Room", "Age", "Gender", "Sexuality", "Generation", "Class"]
             + base_stat_headers + ["Base Sum"]
             + actual_stat_headers + ["Actual Sum"]
-            + ["Abilities", "Mutations", "Aggression", "Libido", "Inbreeding",
-               "Pinned", "Blacklisted", "Must Breed", "Parent A", "Parent B"]
+            + ["Abilities", "Passive Abilities", "Mutations", "Disorders", "Defects",
+               "Aggression", "Libido", "Inbreeding",
+               "Pinned", "Blacklisted", "Must Breed", "Tags",
+               "Lovers", "Haters", "Parent A", "Parent B"]
         )
 
         def _trait(val, field):
             if val is None:
                 return ""
             return _trait_label_from_value(field, val)
+
+        def _names(cats):
+            return "; ".join(c.name for c in (cats or []) if c is not None)
 
         rows = []
         for cat in self._cats:
@@ -4042,18 +4076,25 @@ class MainWindow(QMainWindow):
                     cat.gender or "",
                     cat.sexuality or "",
                     str(cat.generation),
+                    getattr(cat, "cat_class", "") or "",
                 ]
                 + [str(v) for v in base_vals] + [str(sum(base_vals))]
                 + [str(v) for v in actual_vals] + [str(sum(actual_vals))]
                 + [
                     "; ".join(cat.abilities or []),
+                    "; ".join(getattr(cat, "passive_abilities", []) or []),
                     "; ".join(cat.mutations or []),
+                    "; ".join(getattr(cat, "disorders", []) or []),
+                    "; ".join(getattr(cat, "defects", []) or []),
                     _trait(cat.aggression, "aggression"),
                     _trait(cat.libido, "libido"),
                     _trait(cat.inbredness, "inbredness"),
                     "Yes" if getattr(cat, "is_pinned", False) else "No",
                     "Yes" if getattr(cat, "is_blacklisted", False) else "No",
                     "Yes" if getattr(cat, "must_breed", False) else "No",
+                    "; ".join(_cat_tags(cat) or []),
+                    _names(getattr(cat, "lovers", [])),
+                    _names(getattr(cat, "haters", [])),
                     cat.parent_a.name if cat.parent_a else "",
                     cat.parent_b.name if cat.parent_b else "",
                 ]

--- a/src/mewgenics/models/cat_table_model.py
+++ b/src/mewgenics/models/cat_table_model.py
@@ -875,6 +875,17 @@ class CatTableModel(QAbstractTableModel):
             return _make_stat_header_icon(stat_name)
         return None
 
+    @staticmethod
+    def _exceptional_tooltip(cat, prefix: str = "Exceptional breeder") -> str:
+        from mewgenics.utils.thresholds import (
+            SCORE_SOURCE, DETAILED_EXCEPTIONAL_THRESHOLD, _get_detailed_score,
+        )
+        if SCORE_SOURCE == "detailed":
+            score = _get_detailed_score(cat)
+            if score is not None:
+                return f"{prefix}: detailed score {score:+.1f} >= {DETAILED_EXCEPTIONAL_THRESHOLD:+.1f}"
+        return f"{prefix}: base stat sum {_cat_base_sum(cat)} >= {EXCEPTIONAL_SUM_THRESHOLD}"
+
     def data(self, index, role=Qt.DisplayRole):
         if not index.isValid():
             return None
@@ -1073,9 +1084,7 @@ class CatTableModel(QAbstractTableModel):
             if col == COL_NAME:
                 notes: list[str] = []
                 if is_exceptional:
-                    notes.append(
-                        f"Exceptional breeder: base stat sum {_cat_base_sum(cat)} >= {EXCEPTIONAL_SUM_THRESHOLD}"
-                    )
+                    notes.append(self._exceptional_tooltip(cat))
                 if donation_reason:
                     notes.append(f"Donation candidate: {donation_reason}")
                 if notes:
@@ -1135,7 +1144,7 @@ class CatTableModel(QAbstractTableModel):
                 if self._show_total_stats:
                     notes.append(f"Total stat sum: {sum(cat.total_stats.values())}")
                 if is_exceptional:
-                    notes.append(f"Exceptional threshold: >= {EXCEPTIONAL_SUM_THRESHOLD}")
+                    notes.append(self._exceptional_tooltip(cat, prefix="Exceptional threshold"))
                 if donation_reason:
                     notes.append(f"Donation signal: {donation_reason}")
                 return "\n".join(notes)

--- a/src/mewgenics/utils/cat_analysis.py
+++ b/src/mewgenics/utils/cat_analysis.py
@@ -13,7 +13,16 @@ def _cat_base_sum(cat: "Cat") -> int:
 
 
 def _is_exceptional_breeder(cat: "Cat") -> bool:
-    from mewgenics.utils.thresholds import EXCEPTIONAL_SUM_THRESHOLD
+    from mewgenics.utils.thresholds import (
+        EXCEPTIONAL_SUM_THRESHOLD, SCORE_SOURCE,
+        DETAILED_EXCEPTIONAL_THRESHOLD, _get_detailed_score,
+    )
+    if SCORE_SOURCE == "detailed":
+        score = _get_detailed_score(cat)
+        if score is not None:
+            return score >= DETAILED_EXCEPTIONAL_THRESHOLD
+        # Fall back to base sum when the Detailed Scoring cache isn't populated
+        # yet (e.g. view never opened this session).
     return _cat_base_sum(cat) >= EXCEPTIONAL_SUM_THRESHOLD
 
 
@@ -22,11 +31,22 @@ def _has_eternal_youth(cat: "Cat") -> bool:
 
 
 def _donation_candidate_base_reason(cat: "Cat") -> Optional[str]:
-    from mewgenics.utils.thresholds import EXCEPTIONAL_SUM_THRESHOLD, DONATION_SUM_THRESHOLD, DONATION_MAX_TOP_STAT
-    from mewgenics.utils.thresholds import DONATION_MISSING_PLANNER_TRAITS, _donation_planner_traits
+    from mewgenics.utils.thresholds import (
+        EXCEPTIONAL_SUM_THRESHOLD, DONATION_SUM_THRESHOLD, DONATION_MAX_TOP_STAT,
+        DONATION_MISSING_PLANNER_TRAITS, _donation_planner_traits,
+        SCORE_SOURCE, DETAILED_DONATION_THRESHOLD, _get_detailed_score,
+    )
     from mewgenics.utils.abilities import _cat_has_trait
     if _has_eternal_youth(cat):
         return None
+
+    use_detailed = SCORE_SOURCE == "detailed"
+    detailed_score = _get_detailed_score(cat) if use_detailed else None
+    # If the user picked Detailed but the cache is empty, silently fall back
+    # to base-sum so the sidebar never flags every cat at once.
+    if use_detailed and detailed_score is None:
+        use_detailed = False
+
     planner_trait_reason: Optional[str] = None
     planner_mode = False
     if DONATION_MISSING_PLANNER_TRAITS:
@@ -40,19 +60,29 @@ def _donation_candidate_base_reason(cat: "Cat") -> Optional[str]:
                 return None
             missing = ", ".join(str(t.get("display") or t.get("key") or "?") for t in planner_traits[:4])
             planner_trait_reason = f"missing selected planner traits{f' ({missing})' if missing else ''}"
+
     total = _cat_base_sum(cat)
     top_stat = max(cat.base_stats.values()) if cat.base_stats else 0
+
+    def _floor_reasons() -> list[str]:
+        if use_detailed:
+            if detailed_score is not None and detailed_score <= DETAILED_DONATION_THRESHOLD:
+                return [f"detailed score {detailed_score:+.1f} <= {DETAILED_DONATION_THRESHOLD:+.1f}"]
+            return []
+        reasons: list[str] = []
+        if total <= DONATION_SUM_THRESHOLD:
+            reasons.append(f"base sum {total} <= {DONATION_SUM_THRESHOLD}")
+        if top_stat <= DONATION_MAX_TOP_STAT:
+            reasons.append(f"top base stat {top_stat} <= {DONATION_MAX_TOP_STAT}")
+        return reasons
+
     if planner_mode:
         if planner_trait_reason is None:
             return None
-        floor_reasons: list[str] = []
-        if total <= DONATION_SUM_THRESHOLD:
-            floor_reasons.append(f"base sum {total} <= {DONATION_SUM_THRESHOLD}")
-        if top_stat <= DONATION_MAX_TOP_STAT:
-            floor_reasons.append(f"top base stat {top_stat} <= {DONATION_MAX_TOP_STAT}")
-        if not floor_reasons:
+        floor = _floor_reasons()
+        if not floor:
             return None
-        reasons: list[str] = [planner_trait_reason, *floor_reasons]
+        reasons: list[str] = [planner_trait_reason, *floor]
         aggression = cat.aggression
         if aggression is not None and aggression >= 0.66:
             reasons.append("high aggression")
@@ -60,17 +90,17 @@ def _donation_candidate_base_reason(cat: "Cat") -> Optional[str]:
 
     if _is_exceptional_breeder(cat):
         return None
-    reasons: list[str] = []
-    if total <= DONATION_SUM_THRESHOLD:
-        reasons.append(f"base sum {total} <= {DONATION_SUM_THRESHOLD}")
-    if top_stat <= DONATION_MAX_TOP_STAT:
-        reasons.append(f"top base stat {top_stat} <= {DONATION_MAX_TOP_STAT}")
+
+    reasons = _floor_reasons()
     aggression = cat.aggression
     if aggression is not None and aggression >= 0.66:
         reasons.append("high aggression")
     if not reasons:
         return None
-    if total > DONATION_SUM_THRESHOLD and top_stat > DONATION_MAX_TOP_STAT:
+    # In base-sum mode, require both sum AND top-stat to be under the floor —
+    # a single low stat alone isn't enough.  Detailed mode already has a
+    # single-axis floor so we don't apply that gate.
+    if not use_detailed and total > DONATION_SUM_THRESHOLD and top_stat > DONATION_MAX_TOP_STAT:
         return None
     return ", ".join(reasons)
 

--- a/src/mewgenics/utils/thresholds.py
+++ b/src/mewgenics/utils/thresholds.py
@@ -17,6 +17,16 @@ DONATION_SUM_THRESHOLD = int(_BASE_DONATION)
 DONATION_MAX_TOP_STAT = int(_BASE_TOP_STAT)
 DONATION_MISSING_PLANNER_TRAITS = False
 
+# ── Score source ──────────────────────────────────────────────────────────────
+# "base_sum" compares raw base-stat sums against the int thresholds above.
+# "detailed" compares the Detailed Scoring total against the float thresholds
+# below, using the latest cache populated by the Detailed Scoring view.
+SCORE_SOURCE: str = "base_sum"
+DETAILED_EXCEPTIONAL_THRESHOLD: float = 20.0
+DETAILED_DONATION_THRESHOLD: float = -5.0
+
+_DETAILED_SCORES: dict[int, float] = {}
+
 _DONATION_PLANNER_TRAITS: tuple[dict, ...] = ()
 
 _THRESHOLD_CONFIG_KEY = "threshold_preferences"
@@ -28,6 +38,9 @@ _THRESHOLD_DEFAULTS = {
     "adaptive_enabled": False,
     "adaptive_reference_avg_sum": 28.0,
     "adaptive_curve_strength": 0.2,
+    "score_source": "base_sum",
+    "detailed_exceptional_threshold": 20.0,
+    "detailed_donation_threshold": -5.0,
 }
 
 _THRESHOLD_PREFERENCES = dict(_THRESHOLD_DEFAULTS)
@@ -79,7 +92,22 @@ def _normalize_threshold_preferences(data: dict | None) -> dict:
             _THRESHOLD_DEFAULTS["adaptive_curve_strength"],
             min_value=0.0,
         ),
+        "score_source": (
+            "detailed"
+            if str(data.get("score_source", _THRESHOLD_DEFAULTS["score_source"])).strip().lower() == "detailed"
+            else "base_sum"
+        ),
+        "detailed_exceptional_threshold": _coerce_float(
+            data.get("detailed_exceptional_threshold"),
+            _THRESHOLD_DEFAULTS["detailed_exceptional_threshold"],
+        ),
+        "detailed_donation_threshold": _coerce_float(
+            data.get("detailed_donation_threshold"),
+            _THRESHOLD_DEFAULTS["detailed_donation_threshold"],
+        ),
     }
+    if normalized["detailed_exceptional_threshold"] < normalized["detailed_donation_threshold"]:
+        normalized["detailed_exceptional_threshold"] = normalized["detailed_donation_threshold"]
     return _normalize_exceptional_and_donation(normalized)
 
 
@@ -143,10 +171,32 @@ def _effective_thresholds_for_cats(
 
 def _apply_threshold_preferences(prefs: dict | None = None, cats: list[Cat] | None = None):
     global _THRESHOLD_PREFERENCES, EXCEPTIONAL_SUM_THRESHOLD, DONATION_SUM_THRESHOLD, DONATION_MAX_TOP_STAT, DONATION_MISSING_PLANNER_TRAITS
+    global SCORE_SOURCE, DETAILED_EXCEPTIONAL_THRESHOLD, DETAILED_DONATION_THRESHOLD
     normalized = _normalize_threshold_preferences(prefs or _load_threshold_preferences())
     _THRESHOLD_PREFERENCES = normalized
     DONATION_MISSING_PLANNER_TRAITS = bool(normalized.get("donation_missing_planner_traits"))
     EXCEPTIONAL_SUM_THRESHOLD, DONATION_SUM_THRESHOLD, DONATION_MAX_TOP_STAT, _ = _effective_thresholds_for_cats(normalized, cats)
+    SCORE_SOURCE = str(normalized.get("score_source", "base_sum"))
+    DETAILED_EXCEPTIONAL_THRESHOLD = float(normalized.get("detailed_exceptional_threshold", 20.0))
+    DETAILED_DONATION_THRESHOLD = float(normalized.get("detailed_donation_threshold", -5.0))
+
+
+def _set_detailed_scores(scores: dict[int, float] | None):
+    """Install the latest Detailed Scoring totals keyed by id(cat).
+
+    Called from the Detailed Scoring view after each recompute finishes.
+    """
+    global _DETAILED_SCORES
+    _DETAILED_SCORES = dict(scores or {})
+
+
+def _get_detailed_score(cat: Cat) -> float | None:
+    """Return the cached Detailed Scoring total for a cat, or None if unavailable."""
+    return _DETAILED_SCORES.get(id(cat))
+
+
+def _detailed_scores_ready() -> bool:
+    return bool(_DETAILED_SCORES)
 
 
 def _current_threshold_summary(cats: list[Cat] | None = None) -> dict:

--- a/src/mewgenics/views/perfect_planner.py
+++ b/src/mewgenics/views/perfect_planner.py
@@ -21,7 +21,7 @@ from breeding import (
     pair_projection, is_mutual_lover_pair,
     planner_inbreeding_penalty, planner_pair_allows_breeding,
     planner_pair_bias, score_pair as score_pair_factors,
-    tracked_offspring,
+    tracked_offspring, pair_breeding_compatibility,
 )
 from room_optimizer import (
     best_breeding_room_stimulation, build_room_configs,
@@ -1917,6 +1917,31 @@ class PerfectCatPlannerView(QWidget):
 
         controls.addSpacing(12)
 
+        self._min_compat_label = QLabel(_tr(
+            "perfect_planner.min_compat", default="Min breed %"
+        ))
+        self._min_compat_label.setStyleSheet("color:#888; font-size:11px;")
+        controls.addWidget(self._min_compat_label)
+
+        self._min_compat_input = QSpinBox()
+        self._min_compat_input.setRange(0, 100)
+        self._min_compat_input.setValue(15)
+        self._min_compat_input.setSuffix("%")
+        self._min_compat_input.setFixedWidth(70)
+        self._min_compat_input.setToolTip(_tr(
+            "perfect_planner.min_compat_tooltip",
+            default=(
+                "Minimum per-roll breeding compatibility to keep a pair "
+                "(wiki formula: 0.15 × CHA × libido × lover × sexuality).  "
+                "The game auto-rejects pairs below 5%.  Default 15% filters "
+                "out weak pairs while keeping reasonable options."
+            ),
+        ))
+        self._min_compat_input.valueChanged.connect(lambda _: self._save_session_state())
+        controls.addWidget(self._min_compat_input)
+
+        controls.addSpacing(12)
+
         self._starter_label = QLabel(_tr("perfect_planner.start_pairs"))
         self._starter_label.setStyleSheet("color:#888; font-size:11px;")
         controls.addWidget(self._starter_label)
@@ -2400,6 +2425,7 @@ class PerfectCatPlannerView(QWidget):
         state.update({
             "min_stats": self._min_stats_input.text().strip(),
             "max_risk": self._max_risk_input.text().strip(),
+            "min_compat_pct": int(self._min_compat_input.value()),
             "starter_pairs": int(self._starter_pairs_input.value()),
             "stimulation": int(self._stimulation_input.value()),
             "use_sa": bool(self._deep_optimize_btn.isChecked()),
@@ -2626,6 +2652,7 @@ class PerfectCatPlannerView(QWidget):
         try:
             self._min_stats_input.setText(str(state.get("min_stats", "") or ""))
             self._max_risk_input.setText(str(state.get("max_risk", "") or ""))
+            self._min_compat_input.setValue(int(state.get("min_compat_pct", 15) or 0))
             self._starter_pairs_input.setValue(int(state.get("starter_pairs", 4) or 4))
             self._stimulation_input.setValue(int(state.get("stimulation", 50) or 50))
             self._deep_optimize_btn.setChecked(bool(state.get("use_sa", False)))
@@ -2666,6 +2693,7 @@ class PerfectCatPlannerView(QWidget):
         try:
             self._min_stats_input.setText("")
             self._max_risk_input.setText("")
+            self._min_compat_input.setValue(15)
             self._starter_pairs_input.setValue(4)
             self._stimulation_input.setValue(50)
             self._deep_optimize_btn.setChecked(False)
@@ -2738,6 +2766,8 @@ class PerfectCatPlannerView(QWidget):
                 max_risk = float(self._max_risk_input.text().strip())
         except ValueError:
             pass
+
+        min_compat = max(0.0, min(1.0, float(self._min_compat_input.value()) / 100.0))
 
         starter_pairs = int(self._starter_pairs_input.value())
         stimulation = float(self._stimulation_input.value())
@@ -2835,6 +2865,8 @@ class PerfectCatPlannerView(QWidget):
         evaluated_pairs = []
         for pair_index, (cat_a, cat_b) in enumerate(candidate_pairs):
             if not planner_pair_allows_breeding(cat_a, cat_b):
+                continue
+            if min_compat > 0.0 and pair_breeding_compatibility(cat_a, cat_b) < min_compat:
                 continue
             if avoid_lovers and (cat_a.db_key in lover_locked or cat_b.db_key in lover_locked):
                 if not is_mutual_lover_pair(cat_a, cat_b, lover_key_map):
@@ -3107,6 +3139,8 @@ class PerfectCatPlannerView(QWidget):
                     if candidate.db_key in pair_cats:
                         continue
                     if not planner_pair_allows_breeding(parent, candidate):
+                        continue
+                    if min_compat > 0.0 and pair_breeding_compatibility(parent, candidate) < min_compat:
                         continue
                     factors = _score_pair_cached(parent, candidate, stimulation)
                     if not factors.compatible or factors.risk > max_risk:

--- a/src/mewgenics/views/safe_breeding.py
+++ b/src/mewgenics/views/safe_breeding.py
@@ -129,6 +129,14 @@ class SafeBreedingView(QWidget):
             jump_btn.setEnabled(False)
         return jump_btn
 
+    @staticmethod
+    def _filter_toggle_style() -> str:
+        return (
+            "QPushButton { background:#1a1a32; color:#bbb; border:1px solid #2a2a4a;"
+            " border-radius:4px; padding:5px 10px; }"
+            "QPushButton:checked { background:#2a3a5a; color:#fff; border:1px solid #4a6a9a; }"
+        )
+
     def _build_filters_pane(self) -> QWidget:
         pane = QWidget()
         v = QVBoxLayout(pane)
@@ -139,15 +147,11 @@ class SafeBreedingView(QWidget):
         title.setStyleSheet("color:#666; font-size:10px; font-weight:bold;")
         v.addWidget(title)
 
-        self._filter_hide_paired_btn = QPushButton("Hide cats already in love")
-        self._filter_hide_paired_btn.setCheckable(True)
-        self._filter_hide_paired_btn.setStyleSheet(
-            "QPushButton { background:#1a1a32; color:#bbb; border:1px solid #2a2a4a;"
-            " border-radius:4px; padding:5px 10px; }"
-            "QPushButton:checked { background:#2a3a5a; color:#fff; border:1px solid #4a6a9a; }"
-        )
-        self._filter_hide_paired_btn.toggled.connect(self._on_filter_changed)
-        v.addWidget(self._filter_hide_paired_btn)
+        self._filter_hide_left_paired_btn = QPushButton("Hide in-love cats on left")
+        self._filter_hide_left_paired_btn.setCheckable(True)
+        self._filter_hide_left_paired_btn.setStyleSheet(self._filter_toggle_style())
+        self._filter_hide_left_paired_btn.toggled.connect(self._on_filter_changed)
+        v.addWidget(self._filter_hide_left_paired_btn)
 
         risk_row = QHBoxLayout()
         risk_row.setSpacing(6)
@@ -220,7 +224,8 @@ class SafeBreedingView(QWidget):
         self._navigate_to_pair_callback = None
 
         # Filter state. Defaults match "no filtering".
-        self._filter_hide_paired: bool = False
+        self._filter_hide_left_paired: bool = False
+        self._filter_hide_matches_paired: bool = False
         self._filter_max_risk: int = 100
         self._filter_min_quality: float = -999.0
         self._filter_required_mutations: set[str] = set()
@@ -289,6 +294,11 @@ class SafeBreedingView(QWidget):
         mode_layout.addWidget(self._risk_btn)
         mode_layout.addStretch(1)
 
+        self._filter_hide_matches_btn = QPushButton("Hide in-love matches")
+        self._filter_hide_matches_btn.setCheckable(True)
+        self._filter_hide_matches_btn.setStyleSheet(self._filter_toggle_style())
+        self._filter_hide_matches_btn.toggled.connect(self._on_filter_changed)
+
         self._table = QTableWidget(0, self._QUALITY_COLUMN_COUNT)
         self._table.setIconSize(QSize(60, 20))
         self._table.verticalHeader().setVisible(False)
@@ -325,6 +335,7 @@ class SafeBreedingView(QWidget):
         rv.addWidget(self._mode_bar)
         rv.addWidget(self._title)
         rv.addWidget(self._summary)
+        rv.addWidget(self._filter_hide_matches_btn)
         rv.addWidget(self._table, 1)
         root.addWidget(right, 1)
 
@@ -620,10 +631,10 @@ class SafeBreedingView(QWidget):
 
     # ── Filter handlers ─────────────────────────────────────────────
     def _on_filter_changed(self, *_):
-        self._filter_hide_paired = self._filter_hide_paired_btn.isChecked()
+        self._filter_hide_left_paired = self._filter_hide_left_paired_btn.isChecked()
+        self._filter_hide_matches_paired = self._filter_hide_matches_btn.isChecked()
         self._filter_max_risk = int(self._filter_max_risk_spin.value())
         self._filter_min_quality = float(self._filter_min_quality_spin.value())
-        # Hide-paired affects the cat list too — refresh both.
         self._refresh_list()
         cur = self._list.currentItem()
         if cur is not None:
@@ -647,7 +658,8 @@ class SafeBreedingView(QWidget):
             item.setHidden(bool(query) and query not in text)
 
     def _reset_filters(self):
-        self._filter_hide_paired_btn.setChecked(False)
+        self._filter_hide_left_paired_btn.setChecked(False)
+        self._filter_hide_matches_btn.setChecked(False)
         self._filter_max_risk_spin.setValue(100)
         self._filter_min_quality_spin.setValue(-999.0)
         self._filter_mutation_search.clear()
@@ -679,6 +691,14 @@ class SafeBreedingView(QWidget):
             if cat.db_key in self._lover_key_map.get(lover_key, set()):
                 return True
         return False
+
+    def _has_any_lover(self, cat: Cat) -> bool:
+        """True if the cat has any lover, mutual or not.
+
+        Why: once a cat has fallen in love, they can't fall in love again,
+        so for filtering purposes any lover marks them as "taken".
+        """
+        return bool(self._lover_key_map.get(cat.db_key))
 
     def _rebuild_mutation_filter_list(self):
         """Rebuild the filter checklist from the current alive roster."""
@@ -744,10 +764,14 @@ class SafeBreedingView(QWidget):
         for cat in self._alive:
             if query and query not in cat.name.lower():
                 continue
-            if self._filter_hide_paired and self._has_mutual_lover(cat):
+            has_lover = self._has_any_lover(cat)
+            if self._filter_hide_left_paired and has_lover:
                 continue
             room_display = ROOM_DISPLAY.get(cat.room, cat.room or "—")
-            text = f"{cat.name}  ({cat.gender_display})  · {room_display}"
+            heart = " ♥" if has_lover else ""
+            cat_age = getattr(cat, "age", None)
+            age_str = f" · age {cat_age}" if cat_age is not None else ""
+            text = f"{cat.name}{heart}  ({cat.gender_display}){age_str}  · {room_display}"
             if cat.is_blacklisted:
                 text += f"  [{_tr('safe_breeding.list.blocked')}]"
             if cat.must_breed:
@@ -814,6 +838,8 @@ class SafeBreedingView(QWidget):
                 continue
             ok, _ = can_breed(cat, other)
             if not ok:
+                continue
+            if self._filter_hide_matches_paired and self._has_any_lover(other):
                 continue
             if required_muts:
                 if not (self._cat_trait_pool(other) & required_muts):
@@ -966,7 +992,10 @@ class SafeBreedingView(QWidget):
             self._table_row_cat_keys.append(other.db_key)
             row_bg = item.get("row_bg")
             row_fg = item.get("row_fg")
-            name_text = f"{other.name} ({other.gender_display})"
+            other_heart = " ♥" if self._has_any_lover(other) else ""
+            other_age_val = getattr(other, "age", None)
+            other_age = f" · age {other_age_val}" if other_age_val is not None else ""
+            name_text = f"{other.name}{other_heart} ({other.gender_display}){other_age}"
             if item.get("quality") is None:
                 risk_pct = int(round(float(item["risk"])))
                 if risk_pct >= 100:
@@ -977,8 +1006,7 @@ class SafeBreedingView(QWidget):
                     tag, risk_color = _tr("safe_breeding.tag.slightly_inbred"), QColor(143, 201, 230)
                 else:
                     tag, risk_color = _tr("safe_breeding.tag.not_inbred"), QColor(98, 194, 135)
-                heart = " ♥" if item.get("notes") and any("Lover" in note or "lovers" in note.lower() for note in item["notes"]) else ""
-                name_item = QTableWidgetItem(f"{other.name}{heart} ({other.gender_display})")
+                name_item = QTableWidgetItem(name_text)
                 icon = _make_tag_icon(_cat_tags(other), dot_size=14, spacing=4)
                 if not icon.isNull():
                     name_item.setIcon(icon)

--- a/src/save_parser.py
+++ b/src/save_parser.py
@@ -2356,12 +2356,14 @@ def get_grandparents(cat: Cat) -> list[Cat]:
 def can_breed(a: Cat, b: Cat) -> tuple[bool, str]:
     """Return (ok, reason). reason is non-empty only when ok is False.
 
-    The game uses a continuous sexuality_mult rather than hard-blocking:
-      - Male-female: sexuality_mult = cos(0.5*pi * sexuality_coeff)
-      - Same-sex:    sexuality_mult = sin(0.5*pi * sexuality_coeff)
-    Even 'straight' cats (coeff ~0.05) have a small nonzero sin value, so
-    same-sex breeding is technically possible with enough charisma.  We still
-    flag near-zero compatibility as a *warning* rather than a hard block.
+    Game rule (per wiki): compatibility = 0.15 * charisma * libido * lover_mult * sexuality_mult
+    where sexuality_mult = cos(0.5*pi*sexuality_coeff) for opposite-sex pairs
+    and sin(0.5*pi*sexuality_coeff) for same-sex pairs.  A breeding attempt
+    succeeds when compatibility > 0.05.
+
+    So a "straight" cat (coeff ~0) has sin ~0 → same-sex compatibility ~0 →
+    hard block.  A bi/gay cat has non-trivial sin and *can* produce offspring
+    with a same-sex partner.  Symmetric rule for gay+gay opposite-sex.
     """
     if a is b:
         return False, "Cannot pair a cat with itself"


### PR DESCRIPTION
## Summary

- **#102 / #103** — Mating Pair Search filters now hide *any* in-love cat (not just mutual lovers), split into two toggles (left list + matches table), and every cat shows a ♥ when taken plus their age.
- **#104** — Donation/Exceptional thresholds can now be driven by Detailed Scoring. A new *Score source* combo in the thresholds dialog swaps the base-sum thresholds for Detailed Scoring floats. The Detailed Scoring view caches its adjusted totals after each recompute and emits a signal to refresh the sidebar.
- **#101 follow-up (no code change to gate same-sex)** — `can_breed` docstring rewritten to cite the wiki formula verbatim. Same-sex pairs remain legitimate per the game's math (see [issue #101 comment](https://github.com/frankieg33/MewgenicsBreedingManager/issues/101#issuecomment-4315515602)).
- **P7P — Min breed %** — New spinbox (default **15%**) on the planner controls bar. Filters candidate and rotation pairs using the wiki's compat formula `0.15 × CHA × libido × lover_mult × sexuality_mult`, taking the **worst-direction** compat so asymmetric same-sex pairs can't slip past the floor. Foundation (user-picked) pairs bypass.
- **CSV export** — Added Class, Passive Abilities, Disorders, Defects, Tags, Lovers, Haters columns.
- **Startup** — `MainWindow.startup_save_load_finished` signal replaces the fragile QTimer-probe splash hook.

## Why the compat floor uses worst-direction

A bi + straight same-sex pair has very different per-direction compat because `sexuality_mult` is partner-anchored. Best-direction (max) let those pairs slip past a 15% floor even though half of initiations fall below the game's own 5% gate. Worst-direction (min) matches "this pair reliably produces kittens regardless of who initiates."

Sanity check at the 15% default:

| Pair                             | Compat | Outcome       |
|----------------------------------|--------|---------------|
| Straight M+F · CHA4 · libido 0.5 | 29.9%  | passes        |
| Bi F+F · CHA4 · libido 0.5       | 21.2%  | passes        |
| Straight+Bi F+F · CHA4 · lib 0.5 |  2.4%  | **blocked**   |
| Straight M+F · CHA2 · libido 0.3 |  9.0%  | **blocked**   |
| Straight M+F · CHA7 · libido 0.8 | 83.7%  | passes        |
| Gay M+F (same gate as can_breed) |  0.0%  | **blocked**   |

## Files touched

- `src/save_parser.py` — `can_breed` docstring only
- `src/breeding.py` — `estimate_breeding_compatibility` + `pair_breeding_compatibility`
- `src/mewgenics/views/perfect_planner.py` — Min breed % UI + filter
- `src/mewgenics/views/safe_breeding.py` — filter semantics + ♥/age on list items
- `src/mewgenics/main_window.py` — startup signal, CSV columns, detailed-score wiring, adaptive tooltips, save-load cache clear
- `src/mewgenics/app.py` — splash listens on the new signal
- `src/mewgenics/dialogs.py` — score-source combo + Detailed threshold spinboxes
- `src/mewgenics/utils/thresholds.py` — new prefs + `_DETAILED_SCORES` cache + `_set_detailed_scores` / `_get_detailed_score` / `_detailed_scores_ready`
- `src/mewgenics/utils/cat_analysis.py` — `_is_exceptional_breeder` / `_donation_candidate_base_reason` branch on score source
- `src/mewgenics/models/cat_table_model.py` — tooltip copy adapts to score source
- `src/breed_priority/__init__.py` — `detailed_scores_updated` Signal + cache push after each recompute

## Test plan

- [ ] Load a save, confirm P7P shows the new *Min breed %* spinbox (default 15).
- [ ] Run P7P at 15% vs 0% and verify low-CHA / straight-same-sex pairs disappear at 15.
- [ ] Confirm foundation pairs still appear at any floor value.
- [ ] Open Mating Pair Search; toggle the two "hide in-love" buttons and verify ♥/age render in both list and matches.
- [ ] Open Thresholds dialog, flip source to *Detailed Scoring total* → rows switch to float thresholds, preview text updates, and cache-missing note appears if the Detailed view hasn't run this session.
- [ ] Open Detailed Scoring view to populate cache; verify sidebar *Exceptional* / *Donation* counts refresh to reflect the Detailed thresholds.
- [ ] Reload the save, verify the Detailed-score cache clears (sidebar falls back to base-sum until Detailed reruns).
- [ ] Export CSV and XLSX, verify the new columns (Class, Passive Abilities, Disorders, Defects, Tags, Lovers, Haters).
- [ ] App startup: confirm splash closes once the save finishes loading (success path) and when a failed load retries or gives up (failure path).

Pre-existing failing tests (unrelated to this PR): `test_mutation_planner_trait_table_*` in `tests/test_perfect_planner_ui.py`.