### PR TITLE
[codex] Add getting started guide and startup onboarding prompt

### DIFF
--- a/docs/superpowers/specs/2026-04-23-getting-started-help-design.md
+++ b/docs/superpowers/specs/2026-04-23-getting-started-help-design.md
@@ -1,0 +1,383 @@
+# Getting Started Help And First-Run Prompt — Design Spec
+
+## Overview
+
+Expand the existing `Getting Started` dialog into a practical, reusable guide for intermediate Mewgenics players who understand breeding in the game but do not yet understand how to use this app well.
+
+The guide should serve two jobs:
+
+1. Be available at any time from `Help > Getting Started`
+2. Be discoverable on startup through a lightweight first-run prompt
+
+This is not a live UI spotlight tutorial. It is a multi-page walkthrough that explains what each major function is for, when to use it, and what kind of answer it gives the player.
+
+The guide should reflect the app's real value proposition:
+
+- it puts all your cat information in one place
+- it helps you inspect and organize your population
+- it helps you identify weak cats to cull or donate
+- it helps you understand pair recommendations and longer-term breeding plans
+
+The copy should be practical and plainspoken rather than polished marketing language.
+
+## Goals
+
+- Give new-to-the-tool users a clear starting point without overwhelming them
+- Explain the main workflow of the app from roster inspection through planning
+- Explain major views in terms of player decisions, not just UI controls
+- Keep `Getting Started` useful as a permanent help reference
+- Add a startup prompt that asks whether to open the guide, skip once, or always skip
+- Preserve the existing `What's New` flow for release notes
+
+## Non-Goals
+
+- No live guided tour that highlights widgets or forces navigation through the main window
+- No rewrite of `About` or `What's New` into documentation hubs
+- No large-scale documentation system outside the existing dialog flow
+- No dependency on external network content inside the app beyond clickable links
+
+## Existing Context
+
+The app already has:
+
+- `Help > Getting Started`
+- `Help > What's New`
+- `Help > About`
+- an existing `OnboardingDialog` implemented as a `QStackedWidget` with `Back`, `Next`, and `Finish`
+- startup logic that decides whether to show onboarding or `What's New` based on `last_seen_version`
+
+That existing structure should be reused rather than replaced.
+
+## User Experience Summary
+
+### First-Run / Startup Experience
+
+When a user launches the app and onboarding prompting is still enabled, the app should show a small modal prompt before the full guide.
+
+The prompt should not try to teach the app. Its only job is to route the user into the expanded guide or let them dismiss it.
+
+Suggested prompt content:
+
+- Title: `New to Mewgenics Breeding Manager?`
+- Body: short copy explaining that the app has grown a lot and the guide walks through the main workflow and major tools
+- Buttons:
+  - `Open Getting Started`
+  - `Skip This Time`
+  - `Always Skip`
+
+Behavior:
+
+- `Open Getting Started` opens the full guide
+- `Skip This Time` closes the prompt and asks again on a later launch
+- `Always Skip` stores a persistent preference and suppresses future auto-prompts
+- `Help > Getting Started` always remains available regardless of the saved preference
+
+### Help Menu Experience
+
+`Help > Getting Started` should always open the full guide directly.
+
+This should not show the startup prompt first. The prompt is only for automatic startup behavior.
+
+### Guide Experience
+
+The guide remains a modal multi-page dialog with:
+
+- one page title
+- one body area using `QTextBrowser`
+- `Back`, `Next`, and `Finish` buttons
+- a `Page X of Y` label
+
+The dialog remains reusable from Help and from startup.
+
+## Information Architecture
+
+The expanded guide should use nine pages.
+
+### 1. Start Here
+
+Purpose:
+Explain what the app is for in plain language.
+
+Required content:
+
+- The app puts all the information about your cats in one place so you can make better decisions
+- The main use case is understanding your population before deciding what to breed, keep, or cull
+- The common long-term goal is preserving strong stats and strong mutations while removing low-value cats and weak lines
+- A beginner-friendly LLM suggestion appears near the top:
+  - export cats with `File > Export Cats`
+  - give an LLM the exported CSV plus the [Breeding wiki page](https://mewgenics.wiki.gg/wiki/Breeding)
+  - ask what to do next
+
+Tone:
+Very clear and grounded. This page should reduce “where do I even start?” anxiety.
+
+### 2. Your Main Workflow
+
+Purpose:
+Explain the normal loop for using the app.
+
+Required content:
+
+- Load your save
+- Inspect the roster
+- Identify weak cats and obvious cuts
+- Compare promising pair options
+- Use planning tools when you want a longer-term strategy
+- Export and ask for help if you need another layer of interpretation
+
+Key message:
+The app works best as a funnel. Start broad with the full roster, then narrow into scoring, pair analysis, and planning.
+
+### 3. Roster: Your Home Base
+
+Purpose:
+Explain how to use the roster as the default starting point.
+
+Required content:
+
+- Sort and filter to understand your full population
+- Click cats to inspect details
+- Use the roster to compare stats, mutations, disorders, lineage, and other context
+- Use tags and quick actions to stay organized
+
+Key message:
+If you are confused, start in the roster.
+
+### 4. Find Weak Cats Fast
+
+Purpose:
+Teach the fastest path to culling and triage.
+
+Required content:
+
+- `Donation Candidates` is for quick triage and finding the worst offenders
+- `Simple Scoring` is for ranking cats according to your own priorities
+- This is the best place to start if the real goal is to identify shitty cats, weak lines, or obvious cuts
+
+Page structure:
+
+- short intro paragraph
+- one subsection for `Donation Candidates`
+- one subsection for `Simple Scoring`
+- one short “use this when...” summary for each
+
+### 5. Understand Pair Suggestions
+
+Purpose:
+Explain what pair recommendation tools are doing and why their output can be non-obvious.
+
+Required content:
+
+- Pair views are not only matching the two most obviously strong cats
+- The app is searching across many possible combinations and surfacing promising pairs based on tradeoffs
+- A pair may be recommended because it supports a better long-term direction, preserves rare strengths, avoids a worse risk, or complements weaknesses well
+- If the app spits out several top pairs, that is a signal about strategy rather than a command
+
+This page should also include example LLM prompts such as:
+
+- `Why is the tool recommending these 4 pairs?`
+- `What is it trying to optimize for?`
+- `What tradeoffs is it making between these pair options?`
+
+### 6. Detailed Scoring
+
+Purpose:
+Explain when and why to use the more strategic scoring tools.
+
+Required content:
+
+- `Detailed Scoring` is a more strategic ranking tool than `Simple Scoring`
+- It helps when the roster is large enough that quick eyeballing stops working
+- Profiles and weights let the player ask different strategic questions
+- Users do not need to master this immediately
+
+Key message:
+This is the place to come when you want more nuance, not the first tool every user must learn.
+
+### 7. Planning Tools
+
+Purpose:
+Explain longer-horizon tools like room and planner views.
+
+Required content:
+
+- Planning views matter once the player already knows which cats are worth investing in
+- These tools help compare breeding directions, not just one-off cats
+- The value here is project-level planning rather than quick inspection
+
+This page should explain that the app can help the player think in generations, not just individual pair quality.
+
+### 8. Family Tree And Context
+
+Purpose:
+Explain why the app exposes family and context-heavy views.
+
+Required content:
+
+- Good breeding decisions are not just about one cat’s current score
+- Family history and lineage matter
+- Use these views to understand how traits and risks move through a line
+
+Key message:
+The app keeps context because breeding decisions are better when you can see the line behind the cat.
+
+### 9. Export And Ask For Help
+
+Purpose:
+Close the guide with a practical “what next?” page.
+
+Required content:
+
+- Remind the user about `File > Export Cats`
+- Explain that exporting lets the player use outside help without retyping everything
+- Include example prompts:
+  - `Help me decide who to cull first`
+  - `Why are these pairs being recommended`
+  - `What should I do next with this roster`
+  - `Which lines are worth keeping and which should I stop investing in`
+
+This page should reinforce the wiki + CSV + LLM workflow from page 1.
+
+## Copywriting Guidelines
+
+- Write for intermediate players who know Mewgenics breeding concepts but do not know this tool
+- Keep the tone practical, direct, and plainspoken
+- Avoid sounding like release notes or marketing copy
+- Prefer “what this feature is for” over “here is every control on this screen”
+- Use blunt phrasing like “find weak cats fast” or “worst offenders” where it improves clarity
+
+## UI Design Details
+
+### Keep The Existing Dialog Pattern
+
+Reuse the existing `OnboardingDialog` pattern:
+
+- `QDialog`
+- `QStackedWidget`
+- one page per concept
+- `Back`, `Next`, `Finish`
+- `Page X of Y`
+
+This avoids introducing a second documentation surface.
+
+### Suggested Dialog Changes
+
+- Keep the window title as `Getting Started`
+- Change the top heading from `Welcome to Mewgenics Breeding Manager` to something more reusable, such as `Getting Started With Mewgenics Breeding Manager`
+- Keep the existing dark styling unless a separate UI cleanup is needed later
+- Allow links in page bodies
+
+### Readability Constraints
+
+Each page should be:
+
+- one short intro paragraph
+- 3 to 6 bullets or short subsections
+- optionally one short “try this” or “use this when...” block
+
+Pages can scroll, but the design target should be “readable in one sitting,” not mini-manuals.
+
+## Startup Prompt Design
+
+### New Dialog
+
+Add a lightweight startup prompt dialog separate from the full guide.
+
+Responsibilities:
+
+- ask whether the user wants help getting started
+- optionally suppress future startup prompting
+- launch the full guide when requested
+
+This prompt should not replace the full guide. It only decides whether to open it automatically.
+
+### Persisted Preference
+
+Store a dedicated onboarding-prompt preference in app config.
+
+Required shape:
+
+- `show_getting_started_prompt: true/false`
+
+This key must be separate from version tracking and should default to `true` when missing.
+
+### Separation From Release Notes
+
+Do not overload `last_seen_version` for onboarding prompting.
+
+Required behavior:
+
+- `What's New` remains version-driven
+- onboarding prompt remains preference-driven
+
+This avoids conflicts such as:
+
+- a returning user who has skipped onboarding forever but should still see a new release note
+- a first-time user who should see onboarding help without teaching the app through the release-notes dialog
+
+## MainWindow Behavior
+
+Startup flow should become:
+
+1. Check whether startup dialogs have already been shown
+2. If the user has not seen the current version’s release notes, preserve the existing `What's New` behavior
+3. Independently decide whether to show the onboarding/startup prompt
+4. If the user chooses `Open Getting Started`, open the full guide
+
+Ordering requirement:
+
+- First-time users should see the onboarding prompt rather than silently dropping into the main window
+- Returning users with a new version should still get `What's New`
+- If both are eligible, the onboarding prompt should not permanently suppress `What's New`, and vice versa
+
+Recommended handling:
+
+- show `What's New` when needed
+- then show onboarding prompt if onboarding prompting is enabled and the user still qualifies for it
+
+This keeps release messaging and evergreen help separate.
+
+## Implementation Boundaries
+
+Touched areas:
+
+- `src/mewgenics/dialogs.py`
+  - expand the existing `OnboardingDialog`
+  - add the lightweight startup prompt dialog
+- `src/mewgenics/main_window.py`
+  - update startup flow
+  - keep `Help > Getting Started` opening the full guide directly
+- `src/mewgenics/utils/config.py`
+  - add persistent config helpers for onboarding prompt preference
+
+No other architectural changes are required for this feature.
+
+## Edge Cases
+
+- Users who clicked `Always Skip` must still be able to open the guide from `Help`
+- Users upgrading versions should still get `What's New`
+- Users with missing or corrupted config should default to seeing the startup prompt
+- If the guide is opened from Help, it should never write skip preferences just because it was viewed
+
+## Testing Strategy
+
+Manual verification is sufficient for this feature.
+
+Required checks:
+
+- Fresh config shows the startup prompt
+- `Open Getting Started` opens the full guide
+- `Skip This Time` closes the prompt and shows it again next launch
+- `Always Skip` suppresses the prompt on later launches
+- `Help > Getting Started` still works after `Always Skip`
+- `What's New` still appears on version change
+- The new guide pages render correctly and links open externally
+- Page navigation works correctly from first page to last page
+
+## Open Decisions Resolved
+
+- Use the simpler multi-page guide, not a live step-by-step UI spotlight tutorial
+- Support both startup discovery and persistent Help access
+- Target intermediate players who know the game but not the tool
+- Keep the beginner-friendly LLM suggestion near the top of the guide
+- Add feature explanations oriented around player decisions rather than raw control descriptions

--- a/src/mewgenics/dialogs.py
+++ b/src/mewgenics/dialogs.py
@@ -848,6 +848,70 @@ class WhatsNewDialog(QDialog):
         root.addLayout(button_row)
 
 
+class GettingStartedPromptDialog(QDialog):
+    OPEN_GUIDE = "open"
+    SKIP_ONCE = "skip_once"
+    ALWAYS_SKIP = "always_skip"
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.choice = self.SKIP_ONCE
+        self.setModal(True)
+        self.setWindowTitle("Getting Started")
+        self.setMinimumWidth(460)
+        self.setStyleSheet(
+            "QDialog { background:#0d0d1c; }"
+            "QLabel { color:#ddd; }"
+            "QPushButton { background:#1a1a32; color:#aaa; border:1px solid #2a2a4a;"
+            " border-radius:4px; padding:6px 12px; }"
+            "QPushButton:hover { background:#252545; color:#ddd; }"
+        )
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(16, 16, 16, 16)
+        root.setSpacing(12)
+
+        title = QLabel("Open the getting started guide?")
+        title.setStyleSheet("color:#f0f0ff; font-size:18px; font-weight:bold;")
+        root.addWidget(title)
+
+        body = QLabel(
+            "This short guide explains the main roster workflow, breeding tools, and where to export cats when you want outside help."
+        )
+        body.setWordWrap(True)
+        body.setStyleSheet("color:#b9bddf; line-height:1.4;")
+        root.addWidget(body)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch(1)
+
+        open_btn = QPushButton("Open Guide")
+        open_btn.clicked.connect(self._open_guide)
+        button_row.addWidget(open_btn)
+
+        skip_once_btn = QPushButton("Skip Once")
+        skip_once_btn.clicked.connect(self._skip_once)
+        button_row.addWidget(skip_once_btn)
+
+        always_skip_btn = QPushButton("Always Skip")
+        always_skip_btn.clicked.connect(self._always_skip)
+        button_row.addWidget(always_skip_btn)
+
+        root.addLayout(button_row)
+
+    def _open_guide(self):
+        self.choice = self.OPEN_GUIDE
+        self.accept()
+
+    def _skip_once(self):
+        self.choice = self.SKIP_ONCE
+        self.accept()
+
+    def _always_skip(self):
+        self.choice = self.ALWAYS_SKIP
+        self.accept()
+
+
 class OnboardingDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -869,88 +933,115 @@ class OnboardingDialog(QDialog):
         root.setContentsMargins(16, 16, 16, 16)
         root.setSpacing(12)
 
-        title = QLabel("Welcome to Mewgenics Breeding Manager")
+        title = QLabel("Getting Started With Mewgenics Breeding Manager")
         title.setStyleSheet("color:#f0f0ff; font-size:18px; font-weight:bold;")
         root.addWidget(title)
 
         self._stack = QStackedWidget()
         self._stack.addWidget(self._make_page(
-            "1. Load a save",
+            "1. Start Here",
             f"""
-            <p>Start with <b>File > Open Save</b> or your configured default save.</p>
+            <p>This app helps you inspect your save, find strong breeders, compare pairings, and export cat data when you want outside help.</p>
+            <p>A practical workflow is: load your save, use the app to narrow the roster, export a CSV, then ask an LLM or check the community wiki for extra ideas and terminology.</p>
+            <p>Start with <b>File &gt; Open Save</b> or your configured default save.</p>
             <p>The save root currently points to:</p>
             <p><code>{_save_root_dir()}</code></p>
             """,
         ))
         self._stack.addWidget(self._make_page(
-            "2. Sidebar shortcuts",
+            "2. Your Main Workflow",
             """
-            <p>The left sidebar jumps between the most useful views:</p>
+            <p>Most sessions follow the same loop:</p>
             <ul>
-              <li>Room optimizer and Perfect Planner</li>
-              <li>Mating Pair Search and Breeding Partners</li>
-              <li>Family Tree and other info views</li>
+              <li>Start in the roster to sort, filter, and tag cats.</li>
+              <li>Use quick scoring views to identify weak cats, strong cats, and likely breeders.</li>
+              <li>Open pair search or scoring views when you want recommendations.</li>
+              <li>Use planner and family views when you need longer-term context.</li>
+            </ul>
+            <p>You do not need every tab every time. The app is most useful when you jump to the tool that matches your current breeding question.</p>
+            """,
+        ))
+        self._stack.addWidget(self._make_page(
+            "3. Roster: Your Home Base",
+            """
+            <p>The roster is the home base for almost everything. Use it to sort, filter, tag, and inspect cats before opening more specialized tools.</p>
+            <ul>
+              <li>Click column headers to sort by the stats or traits you care about.</li>
+              <li>Use tags and quick actions to mark breeders, experiments, or cats you plan to donate.</li>
+              <li>Open cat details whenever you need a clearer picture before making a pairing decision.</li>
             </ul>
             """,
         ))
         self._stack.addWidget(self._make_page(
-            "3. Roster workflow",
+            "4. Find Weak Cats Fast",
             """
-            <p>Use the main roster to sort, filter, tag, and inspect cats.</p>
+            <p>When you want to trim the roster quickly, start with the built-in shortcuts for weak-cat review.</p>
             <ul>
-              <li>Right-click rows for quick actions.</li>
-              <li>The Tags button opens the tag manager.</li>
-              <li>The status bar version label opens release notes.</li>
+              <li><b>Donation Candidates</b> helps surface cats that are usually safe to give away.</li>
+              <li><b>Simple Scoring</b> is great when you want a fast custom point system for your current breeding goal.</li>
+              <li>Combining filters, tags, and a simple score usually gets you to a manageable shortlist fast.</li>
             </ul>
             """,
         ))
         self._stack.addWidget(self._make_page(
-            "4. Help and accessibility",
+            "5. Understand Pair Suggestions",
             """
-            <p>The Settings menu now includes accessibility presets and saved UI scale controls.</p>
-            <p>The Help menu gives you this walkthrough again, What&apos;s New, and About.</p>
-            <p>Cat sprites require shape assets &mdash; these are extracted automatically from
-            <code>DefinedShapes.zip</code> or the game&apos;s <code>resources.gpak</code> on first launch.</p>
-            """,
-        ))
-        self._stack.addWidget(self._make_page(
-            "5. Cat Scoring &mdash; Detailed Scoring",
-            """
-            <p>The <b>Detailed Scoring</b> view ranks every cat with a breed priority score
-            based on configurable weights. Open it from the <b>Cat Scoring</b> section in the sidebar.</p>
+            <p>Pair-search tools are useful because the app checks a huge number of possible combinations for you.</p>
             <ul>
-              <li><b>Scope:</b> Choose which rooms to include. Scores adjust based on what&apos;s in scope &mdash;
-                  a rare stat-7 is worth more if fewer scope cats share it.</li>
-              <li><b>Weights:</b> Tune how much each factor matters &mdash; stat rarity, genetic risk,
-                  libido, aggression, trait ratings, and more. Hover any weight for a description.</li>
-              <li><b>Trait Ratings:</b> Double-click abilities or mutations in the right panel to rate them
-                  as Top Priority, Desirable, or Undesirable. Cats owning rare top-priority traits score higher.</li>
-              <li><b>Profiles:</b> Save up to 5 independent weight/trait setups so you can switch approaches instantly.</li>
-              <li><b>Heatmap:</b> Toggle color-coding to spot strengths and weaknesses at a glance.</li>
+              <li>Instead of manually eyeballing every match, the app searches many combinations and surfaces the strongest-looking options.</li>
+              <li>If you ever wonder <b>&ldquo;why these 4 pairs?&rdquo;</b>, treat the list as a shortlist generated from the app&apos;s scoring rules and breeding constraints.</li>
+              <li>The right next step is usually to click into a promising pair and inspect the details, not to assume the first result is always the only correct answer.</li>
+            </ul>
+            <ul>
+              <li>Some top pairs are balanced all-rounders.</li>
+              <li>Others are specialized picks for a stat, trait, or safer lineage goal.</li>
             </ul>
             """,
         ))
         self._stack.addWidget(self._make_page(
-            "6. Cat Scoring &mdash; Simple Scoring",
+            "6. Detailed Scoring",
             """
-            <p>The <b>Simple Scoring</b> view lets you assign point values to individual stats,
-            mutations, disorders, and personality traits, then sort by total score.</p>
+            <p><b>Detailed Scoring</b> is the deeper ranking tool when you want more than a quick yes/no filter.</p>
             <ul>
-              <li>Great for specific breeding goals like &ldquo;I need high STR melee cats&rdquo;.</li>
-              <li>Switch between per-mutation weights or blanket desired/undesired mode.</li>
-              <li>Uses its own trait-rating profiles stored per save.</li>
+              <li>It ranks cats using configurable weights, scope, and trait priorities.</li>
+              <li>Use it when you want to understand <i>why</i> a cat rises to the top instead of just seeing a simple total.</li>
+              <li>Profiles let you save different breeding philosophies and switch between them quickly.</li>
+              <li>Heatmap coloring makes strengths and weaknesses easier to scan at a glance.</li>
             </ul>
             """,
         ))
         self._stack.addWidget(self._make_page(
-            "7. Cat Sprites",
+            "7. Planning Tools",
             """
-            <p>The Family Tree view can render in-game cat portraits using sprite data
-            from the game&apos;s <code>resources.gpak</code>.</p>
+            <p>Use the planning views when you are no longer asking &ldquo;Who looks good right now?&rdquo; and have moved on to &ldquo;What should I do over the next few generations?&rdquo;</p>
             <ul>
-              <li>On first launch, shape assets are extracted automatically (~3 s from bundled ZIP, ~25 s from GPAK).</li>
-              <li>Rendered thumbnails are cached on disk for instant loading on subsequent opens.</li>
-              <li>Toggle <b>Show Cat Images</b> in the Family Tree view to enable portraits.</li>
+              <li><b>Perfect Planner</b> helps you map out future breeding steps.</li>
+              <li><b>Room Optimizer</b> helps organize active breeders and room assignments.</li>
+              <li>These tools are best after you already know which cats you want to keep in the program.</li>
+            </ul>
+            """,
+        ))
+        self._stack.addWidget(self._make_page(
+            "8. Family Tree And Context",
+            """
+            <p>The family and context views are where you sanity-check a promising idea before you commit to it.</p>
+            <ul>
+              <li><b>Family Tree</b> helps you understand ancestry, relationships, and how a cat fits into the bigger picture.</li>
+              <li>Use detail views when you need context on traits, parents, offspring, or lineage risks.</li>
+              <li>Good pair suggestions become much easier to trust once you confirm the surrounding family context.</li>
+            </ul>
+            """,
+        ))
+        self._stack.addWidget(self._make_page(
+            "9. Export And Ask For Help",
+            """
+            <p>When you want a second opinion, export your data and ask a focused question.</p>
+            <p>Use <b>File &gt; Export Cats</b>, then share the CSV with your helper tool of choice.</p>
+            <p>Example prompts:</p>
+            <ul>
+              <li>&ldquo;Based on this CSV, which cats look like the best long-term breeders and why?&rdquo;</li>
+              <li>&ldquo;Which cats look safest to donate without hurting my breeding options?&rdquo;</li>
+              <li>&ldquo;What do these mutations and traits mean, and which ones should I prioritize?&rdquo;</li>
             </ul>
             """,
         ))

--- a/src/mewgenics/dialogs.py
+++ b/src/mewgenics/dialogs.py
@@ -918,6 +918,10 @@ class OnboardingDialog(QDialog):
         self.setModal(True)
         self.setWindowTitle("Getting Started")
         self.setMinimumWidth(680)
+        # Default height tall enough that the longest page (Detailed Scoring)
+        # fits without an internal scrollbar on a 1080p screen.
+        self.setMinimumHeight(640)
+        self.resize(760, 720)
         self.setStyleSheet(
             "QDialog { background:#0d0d1c; }"
             "QLabel { color:#ddd; }"

--- a/src/mewgenics/main_window.py
+++ b/src/mewgenics/main_window.py
@@ -778,6 +778,17 @@ class MainWindow(QMainWindow):
         if _saved_show_getting_started_prompt(True):
             self._show_getting_started_prompt()
 
+    def _on_startup_save_load_finished_for_dialogs(self):
+        # Run once on the next idle tick so the splash close + window paint
+        # both finish before the modal prompt blocks the event loop.
+        try:
+            self.startup_save_load_finished.disconnect(
+                self._on_startup_save_load_finished_for_dialogs
+            )
+        except (TypeError, RuntimeError):
+            pass
+        QTimer.singleShot(0, self._maybe_show_startup_dialogs)
+
     def _apply_accessibility_style(self, preset: str):
         app = QApplication.instance()
         if preset == "High Contrast":
@@ -3890,8 +3901,16 @@ class MainWindow(QMainWindow):
 
     def showEvent(self, event):
         super().showEvent(event)
+        # The startup prompt + What's New dialog used to fire from showEvent,
+        # but that runs while the save is still loading — the splash screen
+        # stays parked behind the modal guide because startup_save_load_finished
+        # hasn't fired yet.  Defer to after the save load signal so the splash
+        # closes first, then the prompt appears over the fully populated app.
         if not self._startup_dialogs_shown:
-            QTimer.singleShot(0, self._maybe_show_startup_dialogs)
+            self.startup_save_load_finished.connect(
+                self._on_startup_save_load_finished_for_dialogs,
+                Qt.UniqueConnection,
+            )
 
     def _reset_ui_settings_to_defaults(self):
         """Reset pane sizes and planner inputs without touching save-file data."""

--- a/src/mewgenics/main_window.py
+++ b/src/mewgenics/main_window.py
@@ -48,6 +48,7 @@ from mewgenics.utils.config import (
     _saved_zoom_percent, _set_zoom_percent,
     _saved_font_size_offset, _set_font_size_offset_config,
     _saved_last_seen_version, _set_last_seen_version,
+    _saved_show_getting_started_prompt, _set_show_getting_started_prompt,
     _saved_accessibility_preset, _set_accessibility_preset,
     _saved_total_stats_display, _set_total_stats_display,
     _saved_stat_icon_mode, _set_stat_icon_mode,
@@ -115,6 +116,7 @@ from mewgenics.dialogs import (
     SharedOptimizerSearchSettingsDialog,
     SaveSelectorDialog,
     AboutDialog,
+    GettingStartedPromptDialog,
     OnboardingDialog,
     WhatsNewDialog,
 )
@@ -756,16 +758,25 @@ class MainWindow(QMainWindow):
         if mark_seen:
             _set_last_seen_version(APP_VERSION)
 
+    def _show_getting_started_prompt(self):
+        dlg = GettingStartedPromptDialog(self)
+        if dlg.exec() != QDialog.Accepted:
+            return
+        if dlg.choice == GettingStartedPromptDialog.ALWAYS_SKIP:
+            _set_show_getting_started_prompt(False)
+            return
+        if dlg.choice == GettingStartedPromptDialog.OPEN_GUIDE:
+            self._show_onboarding_dialog(mark_seen=True)
+
     def _maybe_show_startup_dialogs(self):
         if self._startup_dialogs_shown:
             return
         self._startup_dialogs_shown = True
         last_seen = _saved_last_seen_version()
-        if not last_seen:
-            self._show_onboarding_dialog(mark_seen=True)
-            return
         if last_seen != APP_VERSION:
             self._show_whats_new_dialog(mark_seen=True)
+        if _saved_show_getting_started_prompt(True):
+            self._show_getting_started_prompt()
 
     def _apply_accessibility_style(self, preset: str):
         app = QApplication.instance()

--- a/src/mewgenics/utils/config.py
+++ b/src/mewgenics/utils/config.py
@@ -246,6 +246,17 @@ def _set_last_seen_version(version: str):
     _save_app_config(data)
 
 
+def _saved_show_getting_started_prompt(default: bool = True) -> bool:
+    data = _load_app_config()
+    return _coerce_bool(data.get("show_getting_started_prompt"), default)
+
+
+def _set_show_getting_started_prompt(enabled: bool):
+    data = _load_app_config()
+    data["show_getting_started_prompt"] = bool(enabled)
+    _save_app_config(data)
+
+
 def _saved_accessibility_preset(default: str = "Default") -> str:
     data = _load_app_config()
     value = data.get("accessibility_preset", default)


### PR DESCRIPTION
## Summary
Adds a fuller getting-started/onboarding flow for Mewgenics Breeding Manager.

This updates the existing help experience so new users can get a practical walkthrough of the app's main workflow, and adds a startup prompt that lets them open the guide, skip it once, or always skip it.

## What Changed
- added a persisted `show_getting_started_prompt` app-config flag
- added a `GettingStartedPromptDialog` with `Open Guide`, `Skip Once`, and `Always Skip`
- expanded `Help > Getting Started` into a 9-page guide covering roster workflow, weak-cat triage, pair suggestions, planning tools, family context, and CSV/LLM export guidance
- updated `MainWindow` startup flow so `What's New` stays version-driven while the getting-started prompt is preference-driven

## Why
The app has grown enough that intermediate players who know Mewgenics but not this tool need a clearer entry point. The new guide explains what each major function is for and gives beginners an escape hatch through CSV export plus the breeding wiki / LLM workflow.

## Validation
- `python -m py_compile src/mewgenics/utils/config.py`
- `python -m py_compile src/mewgenics/dialogs.py`
- `python -m py_compile src/mewgenics/main_window.py`
- offscreen Qt smoke verification for guide page count/titles, prompt choices, and startup decision flow
