### PR TITLE
fix: shrink Getting Started dialog default height

### DIFF
--- a/src/mewgenics/dialogs.py
+++ b/src/mewgenics/dialogs.py
@@ -918,10 +918,11 @@ class OnboardingDialog(QDialog):
         self.setModal(True)
         self.setWindowTitle("Getting Started")
         self.setMinimumWidth(680)
-        # Default height tall enough that the longest page (Detailed Scoring)
-        # fits without an internal scrollbar on a 1080p screen.
-        self.setMinimumHeight(640)
-        self.resize(760, 720)
+        # Default size tall enough that the longer pages (Detailed Scoring,
+        # Sprites) fit without an internal scrollbar, but not so tall that
+        # short pages leave a huge empty void.
+        self.setMinimumHeight(420)
+        self.resize(760, 560)
         self.setStyleSheet(
             "QDialog { background:#0d0d1c; }"
             "QLabel { color:#ddd; }"


### PR DESCRIPTION
## Summary

Follow-up to #106 — the dialog at 720px tall left a big empty void on short pages (e.g. page 1 "Start Here").  Drop the default to 760×560 and the minimum to 420 so the longer pages still fit without an internal scrollbar but short pages aren't sparse.

## Test plan
- [ ] Open Help > Getting Started; page 1 should not have a giant blank area below the text.
- [ ] Page through to the longest pages (Detailed Scoring, Sprites) — content should still fit without an internal scrollbar at the default size.
- [ ] Resize the dialog smaller; it should stop at ~420px tall.